### PR TITLE
Update seqtk/mergepe

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -9,9 +9,6 @@
             "fastqc": {
                 "git_sha": "7b3315591a149609e27914965f858c9a7e071564"
             },
-            "megahit": {
-                "git_sha": "359f721cc957e484b62b6ce11e91456f4bbce084"
-            },
             "multiqc": {
                 "git_sha": "7b3315591a149609e27914965f858c9a7e071564"
             },

--- a/modules.json
+++ b/modules.json
@@ -16,7 +16,7 @@
                 "git_sha": "7b3315591a149609e27914965f858c9a7e071564"
             },
             "seqtk/mergepe": {
-                "git_sha": "8695533dfd20484882dadc184207204759f9f6f7"
+                "git_sha": "94025957118a2e1a3c72a3d8d6971777327e0315"
             },
             "trimgalore": {
                 "git_sha": "3aacd46da2b221ed47aaa05c413a828538d2c2ae"

--- a/modules/nf-core/modules/seqtk/mergepe/main.nf
+++ b/modules/nf-core/modules/seqtk/mergepe/main.nf
@@ -29,7 +29,8 @@ process SEQTK_MERGEPE {
     def prefix = options.suffix ? "${meta.id}${options.suffix}" : "${meta.id}"
     if (meta.single_end) {
         """
-        cp ${reads} ${prefix}.fastq.gz
+        ln -s ${reads} ${prefix}.fastq.gz
+
         cat <<-END_VERSIONS > versions.yml
         ${getProcessName(task.process)}:
             ${getSoftwareName(task.process)}: \$(echo \$(seqtk 2>&1) | sed 's/^.*Version: //; s/ .*\$//')
@@ -41,7 +42,7 @@ process SEQTK_MERGEPE {
             mergepe \\
             $options.args \\
             ${reads} \\
-            | gzip >> ${prefix}.fastq.gz
+            | gzip -n >> ${prefix}.fastq.gz
 
         cat <<-END_VERSIONS > versions.yml
         ${getProcessName(task.process)}:


### PR DESCRIPTION
Updated the seqtk/mergepe, this fixes #19. Also removed the nf-core megahit module from `modules.json` since we have a local module.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/metatdenovo/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/metatdenovo _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
