### PR TITLE
Lower bbnorm memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
+- [#402](https://github.com/nf-core/metatdenovo/pull/402) - allow the BBNorm process to only use 0.8 of the allocated memory not to fail on oversubscription of memory (@erikrikarddaniel)
 - [#400](https://github.com/nf-core/metatdenovo/pull/400) - fix problems with `COLLECT_STATS` when single end reads are used; closes [#396](https://github.com/nf-core/metatdenovo/issues/396) (@erikrikarddaniel)
 - [#398](https://github.com/nf-core/metatdenovo/pull/398) - make sure the EUKulele database directory is created if it doesn't exist (@erikrikarddaniel)
 - [#391](https://github.com/nf-core/metatdenovo/pull/391),[#392](https://github.com/nf-core/metatdenovo/pull/392) - update the documentation and fix some inconsistencies in which output files are saved (@erikrikarddaniel)

--- a/modules.json
+++ b/modules.json
@@ -18,7 +18,8 @@
                     "bbmap/bbnorm": {
                         "branch": "master",
                         "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
-                        "installed_by": ["modules"]
+                        "installed_by": ["modules"],
+                        "patch": "modules/nf-core/bbmap/bbnorm/bbmap-bbnorm.diff"
                     },
                     "bbmap/index": {
                         "branch": "master",

--- a/modules/nf-core/bbmap/bbnorm/bbmap-bbnorm.diff
+++ b/modules/nf-core/bbmap/bbnorm/bbmap-bbnorm.diff
@@ -1,0 +1,20 @@
+Changes in component 'nf-core/bbmap/bbnorm'
+'modules/nf-core/bbmap/bbnorm/meta.yml' is unchanged
+Changes in 'bbmap/bbnorm/main.nf':
+--- modules/nf-core/bbmap/bbnorm/main.nf
++++ modules/nf-core/bbmap/bbnorm/main.nf
+@@ -29,7 +29,7 @@
+     if ( ! task.memory ) {
+         log.info '[BBNorm]: Available memory not known, defaulting to 3 GB. Specify process memory requirements to change this.'
+     } else {
+-        memory = "-Xmx${Math.round(Math.max(1, Math.floor(task.memory.toGiga() * 0.95)))}g"
++        memory = "-Xmx${Math.round(Math.max(1, Math.floor(task.memory.toGiga() * 0.8)))}g"
+     }
+ 
+     """
+
+'modules/nf-core/bbmap/bbnorm/environment.yml' is unchanged
+'modules/nf-core/bbmap/bbnorm/tests/nextflow.config' is unchanged
+'modules/nf-core/bbmap/bbnorm/tests/main.nf.test.snap' is unchanged
+'modules/nf-core/bbmap/bbnorm/tests/main.nf.test' is unchanged
+************************************************************

--- a/modules/nf-core/bbmap/bbnorm/main.nf
+++ b/modules/nf-core/bbmap/bbnorm/main.nf
@@ -29,7 +29,7 @@ process BBMAP_BBNORM {
     if ( ! task.memory ) {
         log.info '[BBNorm]: Available memory not known, defaulting to 3 GB. Specify process memory requirements to change this.'
     } else {
-        memory = "-Xmx${Math.round(Math.max(1, Math.floor(task.memory.toGiga() * 0.95)))}g"
+        memory = "-Xmx${Math.round(Math.max(1, Math.floor(task.memory.toGiga() * 0.8)))}g"
     }
 
     """


### PR DESCRIPTION
<!--
# nf-core/metatdenovo pull request

Many thanks for contributing to nf-core/metatdenovo!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/metatdenovo/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/metatdenovo/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/metatdenovo _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

Allow the BBNorm process to only use 0.8 of the allocated memory.