### PR TITLE
fix(eukulele): support mags mode by using wildcard instead of hardcoded mets_full

### DIFF
--- a/modules/local/eukulele/search/main.nf
+++ b/modules/local/eukulele/search/main.nf
@@ -13,7 +13,7 @@ process EUKULELE_SEARCH {
     output:
     tuple val(meta), path("*/taxonomy_estimation/*.out.gz"), val("${dbname}") , emit: taxonomy_estimation
     tuple val(meta), path("*/taxonomy_counts/*.csv.gz")                       , emit: taxonomy_counts    , optional: true
-    tuple val(meta), path("*/mets_full/diamond/*")                            , emit: diamond
+    tuple val(meta), path("*/*_full/diamond/*")                               , emit: diamond
 
     path "versions.yml"                                                       , emit: versions
 
@@ -37,7 +37,7 @@ process EUKULELE_SEARCH {
         -s \\
         contigs || rc=\$?
 
-    gzip ${prefix}/mets_full/diamond/*.out
+    gzip ${prefix}/*_full/diamond/*.out
     find ${prefix}/ -name "*.csv" | xargs gzip
     gzip ${prefix}/taxonomy_estimation/*.out
 


### PR DESCRIPTION
When running EUKulele with -m mags, the output is generated in 
     mags_full/diamond/ instead of mets_full/diamond/, causing a gzip error.
     
     Fix: replace hardcoded mets_full with *_full wildcard to support both
     mets and mags modes.
