### PR TITLE
Expose Megahit k-mer/min-count params and document coping with large datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added`
 
+- [#NN](https://github.com/nf-core/metatdenovo/pull/NN) - Expose `--megahit_k_min`, `--megahit_k_max`, `--megahit_k_step`, `--megahit_k_list` and `--megahit_min_count` as hidden params for coping with large datasets, addresses [#453](https://github.com/nf-core/metatdenovo/issues/453) (@erikrikarddaniel)
 - [#452](https://github.com/nf-core/metatdenovo/pull/452) - Add `--diamond_dbs` and kofamscan nf-test coverage (`test_diamond`/`test_kofamscan` profiles) using new small reference datasets (@erikrikarddaniel)
 
 ### `Changed`

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -81,7 +81,14 @@ process {
     }
 
     withName: MEGAHIT {
-        ext.args = { "-m ${task.memory.toBytes()}" }
+        ext.args = { [
+            "-m ${task.memory.toBytes()}",
+            params.megahit_k_min     ? "--k-min ${params.megahit_k_min}"        : '',
+            params.megahit_k_max     ? "--k-max ${params.megahit_k_max}"        : '',
+            params.megahit_k_step    ? "--k-step ${params.megahit_k_step}"      : '',
+            params.megahit_k_list    ? "--k-list ${params.megahit_k_list}"      : '',
+            params.megahit_min_count ? "--min-count ${params.megahit_min_count}" : '',
+        ].join(' ').trim() }
         publishDir = [
             path: { "${params.outdir}/megahit" },
             mode: params.publish_dir_mode,

--- a/docs/large_datasets.md
+++ b/docs/large_datasets.md
@@ -1,7 +1,5 @@
 # nf-core/metatdenovo: Coping with large datasets
 
-## :warning: Please read this documentation on the nf-core website: [https://nf-co.re/metatdenovo/usage](https://nf-co.re/metatdenovo/usage)
-
 ## Introduction
 
 Large projects -- many samples, deep sequencing, or both -- can push Megahit past the memory available on a given system.

--- a/docs/large_datasets.md
+++ b/docs/large_datasets.md
@@ -1,0 +1,45 @@
+# nf-core/metatdenovo: Coping with large datasets
+
+## :warning: Please read this documentation on the nf-core website: [https://nf-co.re/metatdenovo/usage](https://nf-co.re/metatdenovo/usage)
+
+## Introduction
+
+Large projects -- many samples, deep sequencing, or both -- can push Megahit past the memory available on a given system.
+This page gives concrete starting points for three params that can bring memory use back down, in the order we'd suggest trying them, with the caveat below.
+
+Before any of that: the choice of assembler itself matters most.
+Megahit (the pipeline's default, `--assembler megahit`) is substantially less memory-hungry than Spades (`--assembler spades`) for the same data, so if you're running Spades and hitting memory limits, switching to Megahit is the single biggest lever available -- try that before reaching for any of the three params below.
+
+> [!WARNING]
+> Only one of the numbers below (`--bbnorm_target 50`) comes from real, reported experience.
+> The rest are either Megahit's own documented presets or educated-guess starting points, not yet backed by our own benchmarks.
+> Treat them as a first attempt, not a tuned recommendation, and please report back what worked (or didn't) for your dataset via a [GitHub issue](https://github.com/nf-core/metatdenovo/issues) -- that's how this page will get more precise over time.
+
+## The order we'd suggest trying these in
+
+1. **Digital normalization** (`--bbnorm`) -- reduces the total volume of read data going into the assembler, so it's the biggest single lever and the one to reach for first if you're far over budget.
+2. **`--megahit_min_count`** -- a smaller, more surgical adjustment to Megahit's own graph construction; try this if normalization alone doesn't get you far enough, or if you'd rather not touch the input reads at all.
+3. **`--megahit_k_min` / `--megahit_k_max` / `--megahit_k_step`** -- the most aggressive option, since it skips Megahit's most sensitive (and most memory-hungry) low-k iterations entirely. Treat this as a last resort.
+
+See [Usage: Digital normalization](usage.md#digital-normalization) and [Usage: Assembler options](usage.md#assembler-options) for what each param does; this page is just about what values to try.
+
+### 1. Digital normalization
+
+Defaults are `--bbnorm_target 100` and `--bbnorm_min 5`.
+In one >90-sample project combining metagenomics and metatranscriptomics, the default target of 100 was not enough to bring the assembly within reach -- lowering `--bbnorm_target` to `50` was needed to get close to a passing assembly.
+
+Suggested ladder: try the default (100) first; if that's not enough, try 50; if still not enough, go lower still, expecting progressively more loss of low-abundance signal as you do.
+We don't yet have a confirmed value below 50.
+`--bbnorm_min` hasn't been tuned in practice yet -- lowering it (below the default of 5) would retain more of the low-abundance tail rather than discarding it, which is the opposite direction from lowering `--bbnorm_target`, so the two params can be adjusted somewhat independently.
+
+### 2. `--megahit_min_count`
+
+Megahit's own default is 2.
+Megahit's presets don't offer a "large dataset" value for this one -- its `meta-sensitive` preset actually lowers it to 1 (for more sensitivity on small assemblies, the opposite goal).
+As a starting hint, try 3 as a first, modest step up; we don't have a confirmed value for large datasets yet.
+
+### 3. `--megahit_k_min` / `--megahit_k_max` / `--megahit_k_step`
+
+Megahit itself documents a `meta-large` preset for this scenario -- `--k-min 27 --k-max 127 --k-step 10` -- described in its own `--help` text as intended for "large & complex metagenomes, like soil".
+That's the best starting point we have, since it comes from Megahit's own authors rather than from our own testing.
+Expect a real trade-off in sensitivity to low-coverage or short reads at these settings -- this is why it's the last lever to reach for, not the first.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -99,10 +99,20 @@ To turn on digital normalization, use the `--bbnorm` parameter and, if required,
 
 > Please, check the [bbnorm](https://jgi.doe.gov/data-and-tools/software-tools/bbtools/bb-tools-user-guide/bbnorm-guide/) documentation for further information about these programs and how digital normalization works. Remember to check [Parameters](https://nf-co.re/metatdenovo/parameters) page for the all options that can be used for this step.
 
+See also [Assembler options](#assembler-options) below for further ways to reduce Megahit's memory usage on very large datasets.
+
 ### Assembler options
 
 By default, the pipeline uses Megahit (`--assembler megahit`) to assemble the cleaned and trimmed reads to create the reference contigs.
 Megahit is fast and it does not require a lot of memory to run, making it ideal for large sets of samples.
+
+If Megahit still runs out of memory on very large datasets, a few hidden parameters let you tune its k-mer graph construction: `--megahit_min_count`, `--megahit_k_min`, `--megahit_k_max` and `--megahit_k_step` (or `--megahit_k_list` instead of the min/max/step triplet).
+Raising `--megahit_min_count` prunes low-frequency, often erroneous k-mers before the graph is built, and is usually the safest first lever to try.
+Raising `--megahit_k_min` skips the smallest, most memory-hungry k-mer iterations, but at the cost of sensitivity to low-coverage or short reads -- treat it more as a last resort.
+None of these parameters have a pipeline default; when left unset, Megahit uses its own built-in defaults, which are recorded in its own log file (under `megahit/`) for each run.
+See the [Megahit documentation](https://github.com/voutcn/megahit) for the full meaning of these options.
+Combining these with [digital normalization](#digital-normalization) above is another way to cope with very large datasets.
+
 The workflow also supports Spades (`--assembler spades` ) as an alternative.
 The default "flavour" of Spades is set to RNA, but this can be changed using the `--spades_flavor` parameter (see [parameter documentation](/metatdenovo/parameters/#spades_flavor))
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -15,6 +15,8 @@ While the rationale for writing the workflow was metatranscriptomes, there is no
 communities nor genomes rather than transcriptomes.
 Instead, the workflow should be usable for any project in which a de novo assembly followed by quantification and annotation is suitable.
 
+If you're working with a large project -- many samples, deep sequencing, or both -- and expect (or hit) memory problems during assembly, see [Coping with large datasets](large_datasets.md) for concrete params to try, and in which order.
+
 ## Running the workflow
 
 ### Quickstart
@@ -97,9 +99,14 @@ This is normally used if the data set is too large to assemble but can potential
 N.B. digitally normalized reads are used only for the assembly and the full set of sequences will be used for quantification.
 To turn on digital normalization, use the `--bbnorm` parameter and, if required, adjust the `--bbnorm_target` and `--bbnorm_min` parameters.
 
+Digital normalization directly and predictably shrinks the assembler's memory and time footprint, since that scales with the size of the k-mer graph, which in turn scales with the (normalized) k-mer diversity and depth.
+It's a coverage-flattening transform, though, so it comes with a real trade-off: k-mers from low-abundance organisms can fall below `--bbnorm_min` and get discarded outright, which means those organisms can be missing from the assembly entirely, not just under-represented in it.
+It can also distort strain-level variation for the same reason.
+Since normalized reads are only used for the assembly (see the note above), this risk is contained to "what gets assembled" -- it does not bias the abundance counts of whatever does make it into the assembly.
+
 > Please, check the [bbnorm](https://jgi.doe.gov/data-and-tools/software-tools/bbtools/bb-tools-user-guide/bbnorm-guide/) documentation for further information about these programs and how digital normalization works. Remember to check [Parameters](https://nf-co.re/metatdenovo/parameters) page for the all options that can be used for this step.
 
-See also [Assembler options](#assembler-options) below for further ways to reduce Megahit's memory usage on very large datasets.
+See [Coping with large datasets](large_datasets.md) for concrete `--bbnorm_target`/`--bbnorm_min` starting values, how this combines with the [Assembler options](#assembler-options) below, and in which order to try them.
 
 ### Assembler options
 
@@ -107,11 +114,10 @@ By default, the pipeline uses Megahit (`--assembler megahit`) to assemble the cl
 Megahit is fast and it does not require a lot of memory to run, making it ideal for large sets of samples.
 
 If Megahit still runs out of memory on very large datasets, a few hidden parameters let you tune its k-mer graph construction: `--megahit_min_count`, `--megahit_k_min`, `--megahit_k_max` and `--megahit_k_step` (or `--megahit_k_list` instead of the min/max/step triplet).
-Raising `--megahit_min_count` prunes low-frequency, often erroneous k-mers before the graph is built, and is usually the safest first lever to try.
+Raising `--megahit_min_count` prunes low-frequency, often erroneous k-mers before the graph is built, and is a more surgical adjustment than the k-mer options.
 Raising `--megahit_k_min` skips the smallest, most memory-hungry k-mer iterations, but at the cost of sensitivity to low-coverage or short reads -- treat it more as a last resort.
 None of these parameters have a pipeline default; when left unset, Megahit uses its own built-in defaults, which are recorded in its own log file (under `megahit/`) for each run.
-See the [Megahit documentation](https://github.com/voutcn/megahit) for the full meaning of these options.
-Combining these with [digital normalization](#digital-normalization) above is another way to cope with very large datasets.
+See the [Megahit documentation](https://github.com/voutcn/megahit) for the full meaning of these options, and [Coping with large datasets](large_datasets.md) for concrete starting values and where these fit relative to [digital normalization](#digital-normalization) above.
 
 The workflow also supports Spades (`--assembler spades` ) as an alternative.
 The default "flavour" of Spades is set to RNA, but this can be changed using the `--spades_flavor` parameter (see [parameter documentation](/metatdenovo/parameters/#spades_flavor))

--- a/nextflow.config
+++ b/nextflow.config
@@ -42,6 +42,11 @@ params {
     min_contig_length            = 0
     spades_flavor                = 'rna'
     save_formatspades            = false
+    megahit_k_min                = null
+    megahit_k_max                = null
+    megahit_k_step               = null
+    megahit_k_list               = null
+    megahit_min_count            = null
 
     // Mapping options
     save_samtools                = true

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -205,6 +205,41 @@
                     "type": "boolean",
                     "description": "Save the formatted spades fasta file",
                     "fa_icon": "fas fa-download"
+                },
+                "megahit_k_min": {
+                    "type": "integer",
+                    "description": "Minimum k-mer size for MEGAHIT, must be odd and <=255.",
+                    "help_text": "Coarser (larger) minimum k-mer sizes reduce the memory needed for the earliest, most memory-hungry MEGAHIT iterations, at the cost of sensitivity to low-coverage or short reads. Useful as a last resort when MEGAHIT runs out of memory on very large datasets. Cannot be combined with `--megahit_k_list`.",
+                    "fa_icon": "fas fa-ruler-horizontal",
+                    "hidden": true
+                },
+                "megahit_k_max": {
+                    "type": "integer",
+                    "description": "Maximum k-mer size for MEGAHIT, must be odd and <=255.",
+                    "help_text": "Cannot be combined with `--megahit_k_list`.",
+                    "fa_icon": "fas fa-ruler-horizontal",
+                    "hidden": true
+                },
+                "megahit_k_step": {
+                    "type": "integer",
+                    "description": "Increment of k-mer size of each iteration for MEGAHIT, must be even and <=28.",
+                    "help_text": "Cannot be combined with `--megahit_k_list`.",
+                    "fa_icon": "fas fa-ruler-horizontal",
+                    "hidden": true
+                },
+                "megahit_k_list": {
+                    "type": "string",
+                    "description": "Comma-separated list of k-mer sizes for MEGAHIT, all must be odd, in the range 15-255, increment <=28.",
+                    "help_text": "Overrides the default automatic k-mer stepping. Cannot be combined with `--megahit_k_min`, `--megahit_k_max` or `--megahit_k_step`.",
+                    "fa_icon": "fas fa-ruler-horizontal",
+                    "hidden": true
+                },
+                "megahit_min_count": {
+                    "type": "integer",
+                    "description": "Minimum multiplicity for filtering k-mers in MEGAHIT.",
+                    "help_text": "Raising this prunes low-frequency (often erroneous) k-mers before graph construction, reducing memory use. Usually a safer first lever than raising `--megahit_k_min` on very large datasets.",
+                    "fa_icon": "fas fa-filter",
+                    "hidden": true
                 }
             },
             "fa_icon": "fas fa-bezier-curve"

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -209,35 +209,35 @@
                 "megahit_k_min": {
                     "type": "integer",
                     "description": "Minimum k-mer size for MEGAHIT, must be odd and <=255.",
-                    "help_text": "Coarser (larger) minimum k-mer sizes reduce the memory needed for the earliest, most memory-hungry MEGAHIT iterations, at the cost of sensitivity to low-coverage or short reads. Useful as a last resort when MEGAHIT runs out of memory on very large datasets. Cannot be combined with `--megahit_k_list`. See [Usage: Assembler options](https://nf-co.re/metatdenovo/usage#assembler-options) and [Coping with large datasets](https://github.com/nf-core/metatdenovo/blob/dev/docs/large_datasets.md) for suggested starting values.",
+                    "help_text": "Coarser (larger) minimum k-mer sizes reduce the memory needed for the earliest, most memory-hungry MEGAHIT iterations, at the cost of sensitivity to low-coverage or short reads. Useful as a last resort when MEGAHIT runs out of memory on very large datasets. Cannot be combined with `--megahit_k_list`. See [Usage: Assembler options](https://nf-co.re/metatdenovo/usage#assembler-options) and [Coping with large datasets](https://nf-co.re/metatdenovo/docs/large_datasets) for suggested starting values.",
                     "fa_icon": "fas fa-ruler-horizontal",
                     "hidden": true
                 },
                 "megahit_k_max": {
                     "type": "integer",
                     "description": "Maximum k-mer size for MEGAHIT, must be odd and <=255.",
-                    "help_text": "Cannot be combined with `--megahit_k_list`. See [Usage: Assembler options](https://nf-co.re/metatdenovo/usage#assembler-options) and [Coping with large datasets](https://github.com/nf-core/metatdenovo/blob/dev/docs/large_datasets.md) for suggested starting values.",
+                    "help_text": "Cannot be combined with `--megahit_k_list`. See [Usage: Assembler options](https://nf-co.re/metatdenovo/usage#assembler-options) and [Coping with large datasets](https://nf-co.re/metatdenovo/docs/large_datasets) for suggested starting values.",
                     "fa_icon": "fas fa-ruler-horizontal",
                     "hidden": true
                 },
                 "megahit_k_step": {
                     "type": "integer",
                     "description": "Increment of k-mer size of each iteration for MEGAHIT, must be even and <=28.",
-                    "help_text": "Cannot be combined with `--megahit_k_list`. See [Usage: Assembler options](https://nf-co.re/metatdenovo/usage#assembler-options) and [Coping with large datasets](https://github.com/nf-core/metatdenovo/blob/dev/docs/large_datasets.md) for suggested starting values.",
+                    "help_text": "Cannot be combined with `--megahit_k_list`. See [Usage: Assembler options](https://nf-co.re/metatdenovo/usage#assembler-options) and [Coping with large datasets](https://nf-co.re/metatdenovo/docs/large_datasets) for suggested starting values.",
                     "fa_icon": "fas fa-ruler-horizontal",
                     "hidden": true
                 },
                 "megahit_k_list": {
                     "type": "string",
                     "description": "Comma-separated list of k-mer sizes for MEGAHIT, all must be odd, in the range 15-255, increment <=28.",
-                    "help_text": "Overrides the default automatic k-mer stepping. Cannot be combined with `--megahit_k_min`, `--megahit_k_max` or `--megahit_k_step`. See [Usage: Assembler options](https://nf-co.re/metatdenovo/usage#assembler-options) and [Coping with large datasets](https://github.com/nf-core/metatdenovo/blob/dev/docs/large_datasets.md) for suggested starting values.",
+                    "help_text": "Overrides the default automatic k-mer stepping. Cannot be combined with `--megahit_k_min`, `--megahit_k_max` or `--megahit_k_step`. See [Usage: Assembler options](https://nf-co.re/metatdenovo/usage#assembler-options) and [Coping with large datasets](https://nf-co.re/metatdenovo/docs/large_datasets) for suggested starting values.",
                     "fa_icon": "fas fa-ruler-horizontal",
                     "hidden": true
                 },
                 "megahit_min_count": {
                     "type": "integer",
                     "description": "Minimum multiplicity for filtering k-mers in MEGAHIT.",
-                    "help_text": "Raising this prunes low-frequency (often erroneous) k-mers before graph construction, reducing memory use. Usually a safer first lever than raising `--megahit_k_min` on very large datasets. See [Usage: Assembler options](https://nf-co.re/metatdenovo/usage#assembler-options) and [Coping with large datasets](https://github.com/nf-core/metatdenovo/blob/dev/docs/large_datasets.md) for suggested starting values.",
+                    "help_text": "Raising this prunes low-frequency (often erroneous) k-mers before graph construction, reducing memory use. Usually a safer first lever than raising `--megahit_k_min` on very large datasets. See [Usage: Assembler options](https://nf-co.re/metatdenovo/usage#assembler-options) and [Coping with large datasets](https://nf-co.re/metatdenovo/docs/large_datasets) for suggested starting values.",
                     "fa_icon": "fas fa-filter",
                     "hidden": true
                 }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -209,35 +209,35 @@
                 "megahit_k_min": {
                     "type": "integer",
                     "description": "Minimum k-mer size for MEGAHIT, must be odd and <=255.",
-                    "help_text": "Coarser (larger) minimum k-mer sizes reduce the memory needed for the earliest, most memory-hungry MEGAHIT iterations, at the cost of sensitivity to low-coverage or short reads. Useful as a last resort when MEGAHIT runs out of memory on very large datasets. Cannot be combined with `--megahit_k_list`.",
+                    "help_text": "Coarser (larger) minimum k-mer sizes reduce the memory needed for the earliest, most memory-hungry MEGAHIT iterations, at the cost of sensitivity to low-coverage or short reads. Useful as a last resort when MEGAHIT runs out of memory on very large datasets. Cannot be combined with `--megahit_k_list`. See [Usage: Assembler options](https://nf-co.re/metatdenovo/usage#assembler-options) and [Coping with large datasets](https://github.com/nf-core/metatdenovo/blob/dev/docs/large_datasets.md) for suggested starting values.",
                     "fa_icon": "fas fa-ruler-horizontal",
                     "hidden": true
                 },
                 "megahit_k_max": {
                     "type": "integer",
                     "description": "Maximum k-mer size for MEGAHIT, must be odd and <=255.",
-                    "help_text": "Cannot be combined with `--megahit_k_list`.",
+                    "help_text": "Cannot be combined with `--megahit_k_list`. See [Usage: Assembler options](https://nf-co.re/metatdenovo/usage#assembler-options) and [Coping with large datasets](https://github.com/nf-core/metatdenovo/blob/dev/docs/large_datasets.md) for suggested starting values.",
                     "fa_icon": "fas fa-ruler-horizontal",
                     "hidden": true
                 },
                 "megahit_k_step": {
                     "type": "integer",
                     "description": "Increment of k-mer size of each iteration for MEGAHIT, must be even and <=28.",
-                    "help_text": "Cannot be combined with `--megahit_k_list`.",
+                    "help_text": "Cannot be combined with `--megahit_k_list`. See [Usage: Assembler options](https://nf-co.re/metatdenovo/usage#assembler-options) and [Coping with large datasets](https://github.com/nf-core/metatdenovo/blob/dev/docs/large_datasets.md) for suggested starting values.",
                     "fa_icon": "fas fa-ruler-horizontal",
                     "hidden": true
                 },
                 "megahit_k_list": {
                     "type": "string",
                     "description": "Comma-separated list of k-mer sizes for MEGAHIT, all must be odd, in the range 15-255, increment <=28.",
-                    "help_text": "Overrides the default automatic k-mer stepping. Cannot be combined with `--megahit_k_min`, `--megahit_k_max` or `--megahit_k_step`.",
+                    "help_text": "Overrides the default automatic k-mer stepping. Cannot be combined with `--megahit_k_min`, `--megahit_k_max` or `--megahit_k_step`. See [Usage: Assembler options](https://nf-co.re/metatdenovo/usage#assembler-options) and [Coping with large datasets](https://github.com/nf-core/metatdenovo/blob/dev/docs/large_datasets.md) for suggested starting values.",
                     "fa_icon": "fas fa-ruler-horizontal",
                     "hidden": true
                 },
                 "megahit_min_count": {
                     "type": "integer",
                     "description": "Minimum multiplicity for filtering k-mers in MEGAHIT.",
-                    "help_text": "Raising this prunes low-frequency (often erroneous) k-mers before graph construction, reducing memory use. Usually a safer first lever than raising `--megahit_k_min` on very large datasets.",
+                    "help_text": "Raising this prunes low-frequency (often erroneous) k-mers before graph construction, reducing memory use. Usually a safer first lever than raising `--megahit_k_min` on very large datasets. See [Usage: Assembler options](https://nf-co.re/metatdenovo/usage#assembler-options) and [Coping with large datasets](https://github.com/nf-core/metatdenovo/blob/dev/docs/large_datasets.md) for suggested starting values.",
                     "fa_icon": "fas fa-filter",
                     "hidden": true
                 }

--- a/tests/default.nf.test
+++ b/tests/default.nf.test
@@ -9,7 +9,14 @@ nextflow_pipeline {
 
         when {
             params {
-                outdir = "$outputDir"
+                outdir         = "$outputDir"
+                // Non-default values, just to prove these params actually reach Megahit's
+                // command line (see the 'k list' log assertion below). k_min == k_max would
+                // be simpler but Megahit only emits 'intermediate_contigs/k*.local.fa.gz'
+                // (a required module output) when iterating across more than one k value.
+                megahit_k_min  = 25
+                megahit_k_max  = 49
+                megahit_k_step = 12
             }
         }
 
@@ -38,6 +45,7 @@ nextflow_pipeline {
                     path("${params.outdir}/summary_tables/megahit.prodigal.overall_stats.tsv.gz").linesGzip.findAll { l -> l.contains('n_feature_count') },
                 ).match() },
                 { assert path("${params.outdir}/megahit/megahit_assembly.log").readLines().any { l -> l.contains('ALL DONE') } },
+                { assert path("${params.outdir}/megahit/megahit_assembly.log").readLines().any { l -> l.contains('k list: 25,37,49') } },
                 { assert path("${params.outdir}/megahit/megahit_assembly.contigs.fa.gz").linesGzip.size() > 3000 },
                 { assert path("${params.outdir}/samtools/megahit.SAMPLE1_PE.idxstats").readLines().size() > 1600 },
                 { assert path("${params.outdir}/prodigal/megahit.prodigal.gff.gz").linesGzip.findAll { l -> l.contains('CDS') }.size() > 3000 },

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -208,15 +208,15 @@
                 "orf\tchr\tstart\tend\tstrand\tlength\tsample\tcount\ttpm"
             ],
             3000000,
-            4,
-            1,
+            5,
+            2,
             4,
             349986,
             [
                 "sample\tn_post_trimming\tn_non_contaminated\tidxs_n_mapped\tidxs_n_unmapped\tn_feature_count"
             ]
         ],
-        "timestamp": "2026-07-31T13:36:43.713122719",
+        "timestamp": "2026-08-10T20:25:26.121633505",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"


### PR DESCRIPTION
<!--
# nf-core/metatdenovo pull request

Many thanks for contributing to nf-core/metatdenovo!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/metatdenovo/tree/master/docs/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/metatdenovo/tree/master/docs/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/metatdenovo _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

## Description

- Exposes `--megahit_k_min`, `--megahit_k_max`, `--megahit_k_step`, `--megahit_k_list` and `--megahit_min_count` as hidden params (all `null` by default, so Megahit's own defaults apply unless explicitly overridden).
- Extends the default pipeline test (`tests/default.nf.test`) to run with a non-default `--megahit_k_min`/`--megahit_k_max`/`--megahit_k_step` combination and assert Megahit's log reflects it, proving the params actually reach Megahit's command line.
- Adds `docs/large_datasets.md`: concrete starting values for coping with assembly memory pressure (assembler choice, then `--bbnorm`, `--megahit_min_count`, `--megahit_k_min`/`k_max`/`k_step`, in that order), cross-linked from `docs/usage.md`. Only the `--bbnorm_target 50` figure is from real reported experience; the rest are Megahit's own documented presets or flagged explicitly as unvalidated starting hints.
- Expands the existing Digital normalization section in `docs/usage.md` with BBNorm's memory/time benefit vs. its low-abundance-taxon-loss trade-off.

Generated by Claude, reviewed by @erikrikarddaniel before opening.
