### PR TITLE
Add dbCAN CAZyme annotation

### DIFF
--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -27,7 +27,9 @@ env:
 jobs:
   nf-test-changes:
     name: nf-test-changes
-    runs-on: "ubuntu-latest"
+    runs-on: # use self-hosted runners
+      - runs-on=${{ github.run_id }}-nf-test-changes
+      - runner=4cpu-linux-x64
     outputs:
       shard: ${{ steps.set-shards.outputs.shard }}
       total_shards: ${{ steps.set-shards.outputs.total_shards }}
@@ -59,7 +61,9 @@ jobs:
     name: "${{ matrix.profile }} | ${{ matrix.NXF_VER }} | ${{ matrix.shard }}/${{ needs.nf-test-changes.outputs.total_shards }}"
     needs: [nf-test-changes]
     if: ${{ needs.nf-test-changes.outputs.total_shards != '0' }}
-    runs-on: "ubuntu-latest"
+    runs-on: # use self-hosted runners
+      - runs-on=${{ github.run_id }}-nf-test
+      - runner=4cpu-linux-x64
     strategy:
       fail-fast: false
       matrix:
@@ -131,7 +135,9 @@ jobs:
   confirm-pass:
     needs: [nf-test]
     if: always()
-    runs-on: "ubuntu-latest"
+    runs-on: # use self-hosted runners
+      - runs-on=${{ github.run_id }}-confirm-pass
+      - runner=2cpu-linux-x64
     steps:
       - name: One or more tests failed (excluding latest-everything)
         if: ${{ contains(needs.*.result, 'failure') }}

--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -27,9 +27,7 @@ env:
 jobs:
   nf-test-changes:
     name: nf-test-changes
-    runs-on: # use self-hosted runners
-      - runs-on=${{ github.run_id }}-nf-test-changes
-      - runner=4cpu-linux-x64
+    runs-on: "ubuntu-latest"
     outputs:
       shard: ${{ steps.set-shards.outputs.shard }}
       total_shards: ${{ steps.set-shards.outputs.total_shards }}
@@ -61,9 +59,7 @@ jobs:
     name: "${{ matrix.profile }} | ${{ matrix.NXF_VER }} | ${{ matrix.shard }}/${{ needs.nf-test-changes.outputs.total_shards }}"
     needs: [nf-test-changes]
     if: ${{ needs.nf-test-changes.outputs.total_shards != '0' }}
-    runs-on: # use self-hosted runners
-      - runs-on=${{ github.run_id }}-nf-test
-      - runner=4cpu-linux-x64
+    runs-on: "ubuntu-latest"
     strategy:
       fail-fast: false
       matrix:
@@ -135,9 +131,7 @@ jobs:
   confirm-pass:
     needs: [nf-test]
     if: always()
-    runs-on: # use self-hosted runners
-      - runs-on=${{ github.run_id }}-confirm-pass
-      - runner=2cpu-linux-x64
+    runs-on: "ubuntu-latest"
     steps:
       - name: One or more tests failed (excluding latest-everything)
         if: ${{ contains(needs.*.result, 'failure') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added`
 
-- [#NN](https://github.com/nf-core/metatdenovo/pull/NN) - Expose `--megahit_k_min`, `--megahit_k_max`, `--megahit_k_step`, `--megahit_k_list` and `--megahit_min_count` as hidden params for coping with large datasets, addresses [#453](https://github.com/nf-core/metatdenovo/issues/453) (@erikrikarddaniel)
+- [#NN](https://github.com/nf-core/metatdenovo/pull/NN) - Add dbCAN CAZyme annotation (`--skip_dbcan`, `--dbcan_dbpath`), addresses [#60](https://github.com/nf-core/metatdenovo/issues/60)/[#430](https://github.com/nf-core/metatdenovo/issues/430) (@erikrikarddaniel)
+- [#455](https://github.com/nf-core/metatdenovo/pull/455) - Expose `--megahit_k_min`, `--megahit_k_max`, `--megahit_k_step`, `--megahit_k_list` and `--megahit_min_count` as hidden params for coping with large datasets, addresses [#453](https://github.com/nf-core/metatdenovo/issues/453) (@erikrikarddaniel)
 - [#452](https://github.com/nf-core/metatdenovo/pull/452) - Add `--diamond_dbs` and kofamscan nf-test coverage (`test_diamond`/`test_kofamscan` profiles) using new small reference datasets (@erikrikarddaniel)
 
 ### `Changed`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added`
 
-- [#NN](https://github.com/nf-core/metatdenovo/pull/NN) - Add dbCAN CAZyme annotation (`--skip_dbcan`, `--dbcan_dbpath`), addresses [#60](https://github.com/nf-core/metatdenovo/issues/60)/[#430](https://github.com/nf-core/metatdenovo/issues/430) (@erikrikarddaniel)
+- [#457](https://github.com/nf-core/metatdenovo/pull/457) - Add dbCAN CAZyme annotation (`--skip_dbcan`, `--dbcan_dbpath`), addresses [#60](https://github.com/nf-core/metatdenovo/issues/60)/[#430](https://github.com/nf-core/metatdenovo/issues/430) (@erikrikarddaniel)
 - [#455](https://github.com/nf-core/metatdenovo/pull/455) - Expose `--megahit_k_min`, `--megahit_k_max`, `--megahit_k_step`, `--megahit_k_list` and `--megahit_min_count` as hidden params for coping with large datasets, addresses [#453](https://github.com/nf-core/metatdenovo/issues/453) (@erikrikarddaniel)
 - [#452](https://github.com/nf-core/metatdenovo/pull/452) - Add `--diamond_dbs` and kofamscan nf-test coverage (`test_diamond`/`test_kofamscan` profiles) using new small reference datasets (@erikrikarddaniel)
 

--- a/CITATIONS.md
+++ b/CITATIONS.md
@@ -76,6 +76,12 @@
 
 - [Kofamscan](https://github.com/takaram/kofam_scan)
 
+- [dbCAN](https://bcb.unl.edu/dbCAN2/)
+
+  > Zheng J, Ge Q, Yan Y, Zhang X, Huang L, Yin Y. dbCAN3: automated
+  > carbohydrate-active enzyme and substrate annotation. Nucleic Acids
+  > Research, 51(W1):W115-W121, 2023. doi: 10.1093/nar/gkad328
+
 - [HMMsearch](https://www.ebi.ac.uk/Tools/hmmer/search/hmmsearch)
 
 - [EUKulele](https://github.com/AlexanderLabWHOI/EUKulele)

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -343,6 +343,29 @@ process {
         ]
     }
 
+    withName: RUNDBCAN_DATABASE {
+        // We only run protein-mode CAZyme annotation, not CGC/gene-cluster analysis, so skip
+        // downloading the CGC-related database assets (transporter/TF/STP/sulfatase/peptidase DBs).
+        ext.args = '--no-cgc'
+        storeDir = { "${params.dbcan_dbpath}" }
+    }
+
+    withName: RUNDBCAN_CAZYMEANNOTATION {
+        publishDir = [
+            enabled: false
+        ]
+    }
+
+    withName: DBCAN_FORMAT {
+        ext.prefix = { "${params.assembler ?: params.user_assembly_name}.${params.orf_caller ?: params.user_orfs_name}" }
+        publishDir = [
+            path: { "${params.outdir}/summary_tables/" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
+            pattern: "*.dbcan.tsv.gz"
+        ]
+    }
+
     withName: EUKULELE_SEARCH {
         publishDir = [
             path: { "${params.outdir}/eukulele" },

--- a/conf/test.config
+++ b/conf/test.config
@@ -34,4 +34,5 @@ params {
     skip_eukulele  = true
     skip_eggnog    = true
     skip_kofamscan = true
+    skip_dbcan     = true
 }

--- a/conf/test_bbnorm.config
+++ b/conf/test_bbnorm.config
@@ -34,4 +34,5 @@ params {
     skip_eukulele  = true
     skip_eggnog    = true
     skip_kofamscan = true
+    skip_dbcan     = true
 }

--- a/conf/test_dbcan.config
+++ b/conf/test_dbcan.config
@@ -1,0 +1,35 @@
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Nextflow config file for running minimal tests
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Defines input files and everything required to run a fast and simple pipeline test.
+
+    Use as follows:
+        nextflow run nf-core/metatdenovo -profile test_dbcan,<docker/singularity>
+
+----------------------------------------------------------------------------------------
+*/
+
+process {
+    resourceLimits = [
+        cpus: 4,
+        memory: '15.GB',
+        time: '1.h'
+    ]
+}
+
+params {
+    config_profile_name        = 'Test dbcan profile'
+    config_profile_description = 'Minimal test dataset to check pipeline with dbCAN CAZyme annotation added'
+
+    // Input data
+    input = params.pipelines_testdata_base_path + 'metatdenovo/samplesheet/samplesheet.csv'
+
+    // parameters
+    assembler      = 'megahit'
+    orf_caller     = 'prodigal'
+    skip_eukulele  = true
+    skip_eggnog    = true
+    skip_kofamscan = true
+    skip_dbcan     = false
+}

--- a/conf/test_diamond.config
+++ b/conf/test_diamond.config
@@ -33,4 +33,5 @@ params {
     skip_eukulele  = true
     skip_eggnog    = true
     skip_kofamscan = true
+    skip_dbcan     = true
 }

--- a/conf/test_eggnog.config
+++ b/conf/test_eggnog.config
@@ -31,4 +31,5 @@ params {
     skip_eukulele  = true
     skip_eggnog    = false
     skip_kofamscan = true
+    skip_dbcan     = true
 }

--- a/conf/test_eukulele.config
+++ b/conf/test_eukulele.config
@@ -30,5 +30,6 @@ params {
     orf_caller     = 'prodigal'
     skip_eggnog    = true
     skip_kofamscan = true
+    skip_dbcan     = true
     eukulele_db    = 'phylodb'
 }

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -25,7 +25,9 @@ params {
     skip_eukulele   = false
     skip_eggnog     = false
     skip_kofamscan  = true
+    skip_dbcan      = false
     eukulele_db     = 'phylodb'
     eukulele_dbpath = 's3://ngi-igenomes/test-data/metatdenovo/gtdb_eukulele/'
     eggnog_dbpath   = 's3://ngi-igenomes/test-data/metatdenovo/eggnog/'
+    dbcan_dbpath    = 's3://ngi-igenomes/test-data/metatdenovo/dbcan/'
 }

--- a/conf/test_kofamscan.config
+++ b/conf/test_kofamscan.config
@@ -35,4 +35,5 @@ params {
     skip_eukulele  = true
     skip_eggnog    = true
     skip_kofamscan = false
+    skip_dbcan     = true
 }

--- a/conf/test_megahit_prokka.config
+++ b/conf/test_megahit_prokka.config
@@ -31,4 +31,5 @@ params {
     skip_eukulele  = true
     skip_kofamscan = true
     skip_eggnog    = true
+    skip_dbcan     = true
 }

--- a/conf/test_megahit_transdecoder.config
+++ b/conf/test_megahit_transdecoder.config
@@ -31,4 +31,5 @@ params {
     skip_eukulele  = true
     skip_eggnog    = true
     skip_kofamscan = true
+    skip_dbcan     = true
 }

--- a/conf/test_single.config
+++ b/conf/test_single.config
@@ -33,4 +33,5 @@ params {
     skip_eukulele  = true
     skip_eggnog    = true
     skip_kofamscan = true
+    skip_dbcan     = true
 }

--- a/conf/test_spades_prodigal.config
+++ b/conf/test_spades_prodigal.config
@@ -31,4 +31,5 @@ params {
     skip_eukulele  = true
     skip_eggnog    = true
     skip_kofamscan = true
+    skip_dbcan     = true
 }

--- a/docs/output.md
+++ b/docs/output.md
@@ -31,6 +31,7 @@ The pipeline is built using [Nextflow](https://www.nextflow.io/) and the results
   - [Functional and taxonomic annotation](#functional-and-taxonomic-annotation) - Predict the function and the taxonomy of ORFs
     - [EggNOG](#eggnog) - Output from EggNOG-mapper (default; optional)
     - [KOfamSCAN](#kofamscan) - Output KOfamSCAN (optional)
+    - [dbCAN](#dbcan) - Output from dbCAN CAZyme annotation (default; optional)
     - [EUKulele](#eukulele) - Output from EUKulele taxonomy annotation (default; optional)
     - [Diamond taxonomy](#diamond-taxonomy) - Output from the Diamond-based taxonomy processing (optional)
     - [Hmmsearch](#hmmsearch) - Output from HMMER run with user-supplied HMM profiles (optional)
@@ -268,6 +269,19 @@ Quantification of CDS features with `featureCounts` from the [subread](https://s
 
 </details>
 
+#### dbCAN
+
+[dbCAN](https://bcb.unl.edu/dbCAN2/) (`run_dbcan`) will perform CAZyme (carbohydrate-active enzyme) annotation on the ORFs, combining HMM and Diamond search results into a single overview table.
+Only ORFs with at least one hit from any of the underlying tools appear in the output.
+
+<details markdown="1">
+<summary>Output files</summary>
+
+- `summary_tables/`
+  - `<assembly_name>.<orfcaller_name>.dbcan.tsv.gz`: reformatted dbCAN CAZyme annotation overview table
+
+</details>
+
 #### EUKulele
 
 [EUKulele](https://github.com/AlexanderLabWHOI/EUKulele) will perform an analysis to assign taxonomy to the ORFs.
@@ -337,6 +351,7 @@ Filenames start with assembly program and ORF caller, to allow reruns of the pip
   - `<assembly_name>.<orfcaller_name>.emapper.tsv.gz`: reformatted output from EggNOG-mapper.
   - `<assembly_name>.<orfcaller_name>.kofamscan.tsv.gz`: reformatted output from Kofamscan.
   - `<assembly_name>.<orfcaller_name>.kofamscan-uniq.tsv.gz`: reformatted output from Kofamscan with a _single_ row per ORF in contrast to the above.
+  - `<assembly_name>.<orfcaller_name>.dbcan.tsv.gz`: reformatted CAZyme annotation overview table from dbCAN.
   - `<assembly_name>.<orfcaller_name>.{db}_eukulele.tsv.gz`: taxonomic annotation per ORF for specific database.
   - `<assembly_name>.<orfcaller_name>.prokka-annotations.tsv.gz`: reformatted annotation output from Prokka.
   - `<assembly_name>.<orfcaller_name>.<database>.diamond.taxonomy.tsv.gz`: diamond taxonomy parsed into individual taxa

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -246,6 +246,13 @@ Currently, the standard download procedure for the eggNOG database using the `do
 Since release 1.4.0, this pipeline therefore uses `wget` to fetch files from [the current download site](http://eggnog6.embl.de/download/emapperdb-5.0.2).
 :::
 
+A third functional annotation option is CAZyme annotation using [dbCAN](https://bcb.unl.edu/dbCAN2/) (`run_dbcan`), which is also run by
+default and can be skipped with `--skip_dbcan`.
+Its database is downloaded automatically, with the path settable through `--dbcan_dbpath directory` (the same "let the pipeline download it
+once, then reuse the data" advice above applies here too).
+Since the pipeline only runs dbCAN's protein-mode CAZyme annotation (not its gene-cluster/CGC analysis), the download skips the CGC-related
+database assets to save space and time.
+
 A more targeted annotation option offered by the workflow is the possibility for the user to provide a set of
 [HMMER HMM profiles](http://eddylab.org/software/hmmer/Userguide.pdf) through the `--hmmdir dir` or `hmmfiles file0.hmm,file1.hmm,...,filen.hmm`
 parameters.
@@ -254,7 +261,7 @@ which each ORF-HMM combination will be ranked according to score and E-value.
 
 #### How to manually download the databases for functional annotation
 
-There are some cases (e.g. offline run) where you prefer to download the databases before running the pipeline. Currently, `eggnog-mapper` and `kofamscan` use databases that can be downloaded.
+There are some cases (e.g. offline run) where you prefer to download the databases before running the pipeline. Currently, `eggnog-mapper`, `kofamscan` and `dbcan` use databases that can be downloaded.
 
 ##### Eggnog databases
 
@@ -286,6 +293,16 @@ gunzip ko_list.gz
 
 wget https://www.genome.jp/ftp/db/kofam/profiles.tar.gz
 tar -zxf profiles.tar.gz
+```
+
+##### dbCAN database
+
+You can use `run_dbcan` itself (installed alongside the pipeline's dbCAN container, or via `pip install run-dbcan`) to download the database
+into a directory that will be used with `--dbcan_dbpath`.
+The `--no-cgc` flag matches what the pipeline itself uses, since only protein-mode CAZyme annotation is run, not gene-cluster analysis:
+
+```bash
+run_dbcan database --db_dir dbcan --aws_s3 --no-cgc
 ```
 
 ## Example pipeline command with some common features

--- a/modules.json
+++ b/modules.json
@@ -100,6 +100,17 @@
                         "git_sha": "a0fe96944016c6cb69d8b64ffc635c71b76310ae",
                         "installed_by": ["modules"]
                     },
+                    "rundbcan/cazymeannotation": {
+                        "branch": "master",
+                        "git_sha": "5e0b34c7ad0841e3e160b15a0180bf2b9be0e3bf",
+                        "installed_by": ["modules"]
+                    },
+                    "rundbcan/database": {
+                        "branch": "master",
+                        "git_sha": "5e0b34c7ad0841e3e160b15a0180bf2b9be0e3bf",
+                        "installed_by": ["modules"],
+                        "patch": "modules/nf-core/rundbcan/database/rundbcan-database.diff"
+                    },
                     "samtools/flagstat": {
                         "branch": "master",
                         "git_sha": "9339809fcb90af8a8b7051e6cd914894d5c52002",

--- a/modules/local/dbcan/format/environment.yml
+++ b/modules/local/dbcan/format/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - conda-forge::gzip=1.11

--- a/modules/local/dbcan/format/main.nf
+++ b/modules/local/dbcan/format/main.nf
@@ -1,0 +1,33 @@
+process DBCAN_FORMAT {
+    tag "$meta.id"
+    label 'process_low'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/gzip:1.11':
+        'biocontainers/gzip:1.11' }"
+
+    input:
+    tuple val(meta), path(overview)
+
+    output:
+    tuple val(meta), path("*.dbcan.tsv.gz"), emit: dbcantsv
+    tuple val("${task.process}"), val('gzip'), eval('gzip --version 2>&1 | grep "^gzip" | sed "s/^gzip \\([0-9.]\\+\\).*/\\1/"'), emit: versions_gzip, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+
+    """
+    sed 's/^Gene ID/orf/' ${overview} | gzip -c > ${prefix}.dbcan.tsv.gz
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+
+    """
+    gzip -c /dev/null > ${prefix}.dbcan.tsv.gz
+    """
+}

--- a/modules/local/dbcan/format/meta.yml
+++ b/modules/local/dbcan/format/meta.yml
@@ -1,0 +1,63 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "dbcan_format"
+description: Reformat dbCAN's CAZyme annotation overview table into a summary-table-ready TSV
+keywords:
+  - dbcan
+  - cazyme
+  - format
+tools:
+  - "gzip":
+      description: Compression utility
+      homepage: https://www.gnu.org/software/gzip/
+      documentation: https://www.gnu.org/software/gzip/manual/gzip.html
+      licence: ["GPL-3.0-or-later"]
+      identifier: null
+
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id:'sample1' ]`
+    - overview:
+        type: file
+        description: dbCAN CAZyme annotation overview table
+        pattern: "*_overview.tsv"
+
+output:
+  dbcantsv:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1' ]`
+      - "*.dbcan.tsv.gz":
+          type: file
+          description: Reformatted dbCAN CAZyme annotation for summary tables
+          pattern: "*.dbcan.tsv.gz"
+  versions_gzip:
+    - - "${task.process}":
+          type: string
+          description: The name of the process
+      - "gzip":
+          type: string
+          description: The name of the tool
+      - "gzip --version":
+          type: eval
+          description: The expression to obtain the version of the tool
+
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - gzip:
+          type: string
+          description: The name of the tool
+      - gzip --version:
+          type: eval
+          description: The expression to obtain the version of the tool
+authors:
+  - "@erikrikarddaniel"
+maintainers:
+  - "@erikrikarddaniel"

--- a/modules/local/dbcan/sum/environment.yml
+++ b/modules/local/dbcan/sum/environment.yml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - conda-forge::r-tidyverse=2.0.0
+  - conda-forge::r-dtplyr=1.3.1
+  - conda-forge::r-data.table=1.14.8

--- a/modules/local/dbcan/sum/main.nf
+++ b/modules/local/dbcan/sum/main.nf
@@ -1,0 +1,73 @@
+process DBCAN_SUM {
+    tag "$meta.id"
+    label 'process_low'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/mulled-v2-b2ec1fea5791d428eebb8c8ea7409c350d31dada:a447f6b7a6afde38352b24c30ae9cd6e39df95c4-1' :
+        'biocontainers/mulled-v2-b2ec1fea5791d428eebb8c8ea7409c350d31dada:a447f6b7a6afde38352b24c30ae9cd6e39df95c4-1' }"
+
+    input:
+    tuple val(meta), path(dbcan)
+    path(fcs)
+
+    output:
+    tuple val(meta), path("${meta.id}.dbcan_summary.tsv.gz") , emit: dbcan_summary
+    path "versions.yml"                                      , emit: versions, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+
+    """
+    #!/usr/bin/env Rscript
+
+    library(dplyr)
+    library(readr)
+    library(tidyr)
+    library(stringr)
+    library(tidyverse)
+
+    # call the tables into variables
+    dbcan <- read_tsv("${dbcan}", show_col_types = FALSE )
+
+    counts <- list.files(pattern = "*.counts.tsv.gz") %>%
+        map_df(~read_tsv(.,  show_col_types  = FALSE)) %>%
+        mutate(sample = as.character(sample))
+
+    counts %>%
+        inner_join(dbcan, by = 'orf') %>%
+        group_by(sample) %>%
+        summarise(value = sum(count), .groups = 'drop') %>%
+        add_column(database = "dbcan", field = "n") %>%
+        relocate(value, .after = last_col()) %>%
+        write_tsv('${meta.id}.dbcan_summary.tsv.gz')
+
+    writeLines(
+        c(
+            "\\"${task.process}\\":",
+            paste0("    R: ", paste0(R.Version()[c("major","minor")], collapse = ".")),
+            paste0("    dplyr: ", packageVersion('dplyr')),
+            paste0("    dtplyr: ", packageVersion('dtplyr')),
+            paste0("    data.table: ", packageVersion('data.table')),
+            paste0("    readr: ", packageVersion('readr')),
+            paste0("    purrr: ", packageVersion('purrr')),
+            paste0("    tidyr: ", packageVersion('tidyr')),
+            paste0("    stringr: ", packageVersion('stringr'))
+        ),
+        "versions.yml"
+    )
+    """
+
+    stub:
+
+    """
+    gzip -c /dev/null > ${meta.id}.dbcan_summary.tsv.gz
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        R: 4.0
+    END_VERSIONS
+    """
+}

--- a/modules/local/dbcan/sum/meta.yml
+++ b/modules/local/dbcan/sum/meta.yml
@@ -1,0 +1,32 @@
+name: "dbcan_sum"
+description: Summarizes dbCAN CAZyme annotation results and combines with feature counts
+keywords:
+  - dbcan
+  - cazyme
+  - summary
+input:
+  - meta:
+      type: map
+      description: Groovy Map containing sample information
+  - dbcan:
+      type: file
+      description: Reformatted dbCAN CAZyme annotation table
+      pattern: "*.dbcan.tsv.gz"
+  - fcs:
+      type: file
+      description: Feature counts files
+      pattern: "*.counts.tsv.gz"
+output:
+  - meta:
+      type: map
+      description: Groovy Map containing sample information
+  - dbcan_summary:
+      type: file
+      description: Summarized dbCAN CAZyme annotation results
+      pattern: "*.dbcan_summary.tsv.gz"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+authors:
+  - "@erikrikarddaniel"

--- a/modules/nf-core/rundbcan/cazymeannotation/environment.yml
+++ b/modules/nf-core/rundbcan/cazymeannotation/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::dbcan=5.2.9

--- a/modules/nf-core/rundbcan/cazymeannotation/main.nf
+++ b/modules/nf-core/rundbcan/cazymeannotation/main.nf
@@ -1,0 +1,49 @@
+process RUNDBCAN_CAZYMEANNOTATION {
+    tag "${meta.id}"
+    label 'process_medium'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/dbcan:5.2.9--pyhdfd78af_0' :
+        'quay.io/biocontainers/dbcan:5.2.9--pyhdfd78af_0' }"
+
+    input:
+    tuple val(meta), path(input_raw_data)
+    path dbcan_db
+
+    output:
+    tuple val(meta), path("${prefix}_overview.tsv"), emit: cazyme_annotation
+    tuple val(meta), path("${prefix}_dbCAN_hmm_results.tsv"), emit: dbcanhmm_results
+    tuple val(meta), path("${prefix}_dbCANsub_hmm_results.tsv"), emit: dbcansub_results
+    tuple val(meta), path("${prefix}_diamond.out"), emit: dbcandiamond_results
+    tuple val("${task.process}"), val('rundbcan'), eval("run_dbcan version | sed 's/dbCAN version: //g'"), emit: versions_rundbcan, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    run_dbcan CAZyme_annotation \\
+        --mode protein \\
+        --db_dir ${dbcan_db} \\
+        --input_raw_data ${input_raw_data} \\
+        --output_dir . \\
+        ${args}
+
+    mv overview.tsv ${prefix}_overview.tsv
+    mv dbCAN_hmm_results.tsv ${prefix}_dbCAN_hmm_results.tsv
+    mv dbCANsub_hmm_results.tsv ${prefix}_dbCANsub_hmm_results.tsv
+    mv diamond.out ${prefix}_diamond.out
+    """
+
+    stub:
+    prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}_overview.tsv
+    touch ${prefix}_dbCAN_hmm_results.tsv
+    touch ${prefix}_dbCANsub_hmm_results.tsv
+    touch ${prefix}_diamond.out
+    """
+}

--- a/modules/nf-core/rundbcan/cazymeannotation/meta.yml
+++ b/modules/nf-core/rundbcan/cazymeannotation/meta.yml
@@ -1,0 +1,107 @@
+name: "rundbcan_cazymeannotation"
+description: CAZyme annotation module for the dbcan pipeline. This module is
+  used to annotate carbohydrate-active enzymes (CAZymes) from genomic data using
+  the dbCAN annotation tool.
+keywords:
+  - dbCAN
+  - download
+  - CAZyme
+  - CAZyme gene Cluster
+  - genomes
+tools:
+  - "dbcan":
+      description: "Standalone version of dbCAN annotation tool for automated CAZyme
+        annotation."
+      homepage: "https://bcb.unl.edu/dbCAN2/"
+      documentation: "https://run-dbcan.readthedocs.io/en/latest/"
+      tool_dev_url: "https://github.com/bcb-unl/run_dbcan"
+      doi: "10.1093/nar/gkad328"
+      licence:
+        - "GPL v3-or-later"
+      identifier: biotools:dbcan
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id:'sample1' ]`
+    - input_raw_data:
+        type: file
+        description: FASTA file for protein sequences.
+        pattern: "*.{fasta,fa,faa}"
+        ontologies:
+          - edam: "http://edamontology.org/data_2044"
+          - edam: "http://edamontology.org/format_1929"
+  - dbcan_db:
+      type: directory
+      description: Path to the dbCAN database directory.
+output:
+  cazyme_annotation:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1']`
+      - ${prefix}_overview.tsv:
+          type: file
+          description: |
+            TSV file containing the results of dbCAN CAZyme annotation.
+          ontologies: []
+  dbcanhmm_results:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1']`
+      - ${prefix}_dbCAN_hmm_results.tsv:
+          type: file
+          description: |
+            TSV file containing the detailed dbCAN HMM results for CAZyme annotation.
+          ontologies: []
+  dbcansub_results:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1']`
+      - ${prefix}_dbCANsub_hmm_results.tsv:
+          type: file
+          description: |
+            TSV file containing the detailed dbCAN subfamily results for CAZyme annotation.
+          ontologies: []
+  dbcandiamond_results:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1']`
+      - ${prefix}_diamond.out:
+          type: file
+          description: |
+            TSV file containing the detailed dbCAN diamond results for CAZyme annotation.
+          ontologies: []
+  versions_rundbcan:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - rundbcan:
+          type: string
+          description: The name of the tool
+      - "run_dbcan version | sed 's/dbCAN version: //g'":
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - rundbcan:
+          type: string
+          description: The name of the tool
+      - "run_dbcan version | sed 's/dbCAN version: //g'":
+          type: eval
+          description: The expression to obtain the version of the tool
+authors:
+  - "@Xinpeng021001"
+maintainers:
+  - "@Xinpeng021001"

--- a/modules/nf-core/rundbcan/cazymeannotation/tests/main.nf.test
+++ b/modules/nf-core/rundbcan/cazymeannotation/tests/main.nf.test
@@ -1,0 +1,66 @@
+nextflow_process {
+
+    name "Test Process RUNDBCAN_CAZYMEANNOTATION"
+    script "../main.nf"
+    process "RUNDBCAN_CAZYMEANNOTATION"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "rundbcan"
+    tag "rundbcan/database"
+    tag "rundbcan/cazymeannotation"
+
+    test("dbcancazyme - simplified") {
+
+        setup {
+            run("RUNDBCAN_DATABASE"){
+                script "../../database/main.nf"
+                process {
+                    """
+                    """
+                }
+            }
+        }
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [id:'test'],
+                    file(params.modules_testdata_base_path + 'genomics/prokaryotes/candidatus_portiera_aleyrodidarum/genome/proteome.fasta', checkIfExists: true)
+                ]
+                input[1] = RUNDBCAN_DATABASE.out.dbcan_db
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assertAll(
+                { assert snapshot(process.out).match()
+                }
+            )
+        }
+    }
+
+    test("dbcancazyme - cazyme annotation - stub") {
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [[id: 'stub'],file('stub') ]
+                input[1] = file('stub_db')
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assertAll(
+                { assert snapshot(process.out).match()
+                }
+            )
+        }
+    }
+}

--- a/modules/nf-core/rundbcan/cazymeannotation/tests/main.nf.test.snap
+++ b/modules/nf-core/rundbcan/cazymeannotation/tests/main.nf.test.snap
@@ -1,0 +1,180 @@
+{
+    "dbcancazyme - cazyme annotation - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "stub"
+                        },
+                        "stub_overview.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "stub"
+                        },
+                        "stub_dbCAN_hmm_results.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "stub"
+                        },
+                        "stub_dbCANsub_hmm_results.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "stub"
+                        },
+                        "stub_diamond.out:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "4": [
+                    [
+                        "RUNDBCAN_CAZYMEANNOTATION",
+                        "rundbcan",
+                        "5.2.9"
+                    ]
+                ],
+                "cazyme_annotation": [
+                    [
+                        {
+                            "id": "stub"
+                        },
+                        "stub_overview.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "dbcandiamond_results": [
+                    [
+                        {
+                            "id": "stub"
+                        },
+                        "stub_diamond.out:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "dbcanhmm_results": [
+                    [
+                        {
+                            "id": "stub"
+                        },
+                        "stub_dbCAN_hmm_results.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "dbcansub_results": [
+                    [
+                        {
+                            "id": "stub"
+                        },
+                        "stub_dbCANsub_hmm_results.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_rundbcan": [
+                    [
+                        "RUNDBCAN_CAZYMEANNOTATION",
+                        "rundbcan",
+                        "5.2.9"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-04-20T12:23:30.010346172",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "24.10.3"
+        }
+    },
+    "dbcancazyme - simplified": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_overview.tsv:md5,946555b9669d8e0b1705ca512ad3c60d"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_dbCAN_hmm_results.tsv:md5,7ce7b6536845ffa8907b3f3fb2b77a1b"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_dbCANsub_hmm_results.tsv:md5,d771df5ab5b2967ced24c04fe54abf17"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_diamond.out:md5,f6d902c0af43d8b33a41d647327c673e"
+                    ]
+                ],
+                "4": [
+                    [
+                        "RUNDBCAN_CAZYMEANNOTATION",
+                        "rundbcan",
+                        "5.2.9"
+                    ]
+                ],
+                "cazyme_annotation": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_overview.tsv:md5,946555b9669d8e0b1705ca512ad3c60d"
+                    ]
+                ],
+                "dbcandiamond_results": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_diamond.out:md5,f6d902c0af43d8b33a41d647327c673e"
+                    ]
+                ],
+                "dbcanhmm_results": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_dbCAN_hmm_results.tsv:md5,7ce7b6536845ffa8907b3f3fb2b77a1b"
+                    ]
+                ],
+                "dbcansub_results": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_dbCANsub_hmm_results.tsv:md5,d771df5ab5b2967ced24c04fe54abf17"
+                    ]
+                ],
+                "versions_rundbcan": [
+                    [
+                        "RUNDBCAN_CAZYMEANNOTATION",
+                        "rundbcan",
+                        "5.2.9"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-04-20T12:23:24.276249869",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "24.10.3"
+        }
+    }
+}

--- a/modules/nf-core/rundbcan/database/environment.yml
+++ b/modules/nf-core/rundbcan/database/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::dbcan=5.2.9

--- a/modules/nf-core/rundbcan/database/main.nf
+++ b/modules/nf-core/rundbcan/database/main.nf
@@ -1,0 +1,31 @@
+process RUNDBCAN_DATABASE {
+    label 'process_low'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/dbcan:5.2.9--pyhdfd78af_0' :
+        'quay.io/biocontainers/dbcan:5.2.9--pyhdfd78af_0' }"
+
+    output:
+    path "dbcan_db", emit: dbcan_db
+    // No version-reporting output here: storeDir only supports `val`/`path` outputs, not the
+    // `tuple`+`eval` shape the official module uses -- and RUNDBCAN_CAZYMEANNOTATION already
+    // reports the same dbCAN version, so nothing is lost.
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    """
+    run_dbcan database \\
+        ${args} \\
+        --db_dir dbcan_db \\
+        --aws_s3
+    """
+
+    stub:
+    """
+    mkdir -p dbcan_db
+    """
+}

--- a/modules/nf-core/rundbcan/database/meta.yml
+++ b/modules/nf-core/rundbcan/database/meta.yml
@@ -1,0 +1,52 @@
+name: "rundbcan_database"
+description: command from run_dbcan to prepare the database for dbCAN
+  annotation.
+keywords:
+  - dbCAN
+  - download
+  - CAZyme
+  - CAZyme gene Cluster
+  - genomes
+tools:
+  - "run_dbcan":
+      description: "Standalone version of dbCAN annotation tool for automated CAZyme
+        annotation."
+      homepage: "https://bcb.unl.edu/dbCAN2/"
+      documentation: "https://run-dbcan.readthedocs.io/en/latest/"
+      tool_dev_url: "https://github.com/bcb-unl/run_dbcan"
+      doi: "10.1093/nar/gkad328"
+      licence:
+        - "GPL v3-or-later"
+      identifier: biotools:dbcan
+input: []
+output:
+  dbcan_db:
+    - dbcan_db:
+        type: directory
+        description: Download directory for dbCAN databases
+        pattern: "dbcan_db"
+  versions_rundbcan:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - rundbcan:
+          type: string
+          description: The name of the tool
+      - "run_dbcan version | sed 's/dbCAN version: //g'":
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - rundbcan:
+          type: string
+          description: The name of the tool
+      - "run_dbcan version | sed 's/dbCAN version: //g'":
+          type: eval
+          description: The expression to obtain the version of the tool
+authors:
+  - "@Xinpeng021001"
+maintainers:
+  - "@Xinpeng021001"

--- a/modules/nf-core/rundbcan/database/rundbcan-database.diff
+++ b/modules/nf-core/rundbcan/database/rundbcan-database.diff
@@ -1,0 +1,30 @@
+Changes in component 'nf-core/rundbcan/database'
+'modules/nf-core/rundbcan/database/meta.yml' is unchanged
+Changes in 'rundbcan/database/main.nf':
+--- modules/nf-core/rundbcan/database/main.nf
++++ modules/nf-core/rundbcan/database/main.nf
+@@ -8,14 +8,18 @@
+ 
+     output:
+     path "dbcan_db", emit: dbcan_db
+-    tuple val("${task.process}"), val('rundbcan'), eval("run_dbcan version | sed 's/dbCAN version: //g'"), emit: versions_rundbcan, topic: versions
++    // No version-reporting output here: storeDir only supports `val`/`path` outputs, not the
++    // `tuple`+`eval` shape the official module uses -- and RUNDBCAN_CAZYMEANNOTATION already
++    // reports the same dbCAN version, so nothing is lost.
+ 
+     when:
+     task.ext.when == null || task.ext.when
+ 
+     script:
++    def args = task.ext.args ?: ''
+     """
+     run_dbcan database \\
++        ${args} \\
+         --db_dir dbcan_db \\
+         --aws_s3
+     """
+
+'modules/nf-core/rundbcan/database/environment.yml' is unchanged
+'modules/nf-core/rundbcan/database/tests/main.nf.test.snap' is unchanged
+'modules/nf-core/rundbcan/database/tests/main.nf.test' is unchanged
+************************************************************

--- a/modules/nf-core/rundbcan/database/tests/main.nf.test
+++ b/modules/nf-core/rundbcan/database/tests/main.nf.test
@@ -1,0 +1,53 @@
+nextflow_process {
+
+    name "Test Process RUNDBCAN_DATABASE"
+    script "../main.nf"
+    process "RUNDBCAN_DATABASE"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "rundbcan"
+    tag "rundbcan/database"
+
+    test("rundbcan - database - basic") {
+
+        when {
+            process {
+                """
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assert path(process.out.dbcan_db.get(0)).exists()
+            assertAll(
+                { assert snapshot(
+                    process.out.findAll { key, val -> key.startsWith('versions') }
+                ).match() }
+            )
+        }
+    }
+
+    test("rundbcan - database - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assertAll(
+                { assert snapshot(
+                    file(process.out.dbcan_db.get(0)).name,
+                    process.out.findAll { key, val -> key.startsWith('versions') }
+                ).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/rundbcan/database/tests/main.nf.test.snap
+++ b/modules/nf-core/rundbcan/database/tests/main.nf.test.snap
@@ -1,0 +1,39 @@
+{
+    "rundbcan - database - basic": {
+        "content": [
+            {
+                "versions_rundbcan": [
+                    [
+                        "RUNDBCAN_DATABASE",
+                        "rundbcan",
+                        "5.2.9"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-04-20T12:35:23.340092811",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "24.10.3"
+        }
+    },
+    "rundbcan - database - stub": {
+        "content": [
+            "dbcan_db",
+            {
+                "versions_rundbcan": [
+                    [
+                        "RUNDBCAN_DATABASE",
+                        "rundbcan",
+                        "5.2.9"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-04-20T12:35:29.047040575",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "24.10.3"
+        }
+    }
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -76,6 +76,10 @@ params {
     kofam_ko_list_url            = 'https://www.genome.jp/ftp/db/kofam/ko_list.gz'
     kofam_profiles_url           = 'https://www.genome.jp/ftp/db/kofam/profiles.tar.gz'
 
+    // CAZyme options
+    skip_dbcan                   = false
+    dbcan_dbpath                 = 'dbcan'
+
     // Taxonomy options
     diamond_dbs                  = null
     diamond_top                  = 10
@@ -237,6 +241,7 @@ profiles {
     test_full                 { includeConfig 'conf/test_full.config'                 }
     test_megahit_prokka       { includeConfig 'conf/test_megahit_prokka.config'       }
     test_megahit_transdecoder { includeConfig 'conf/test_megahit_transdecoder.config' }
+    test_dbcan                { includeConfig 'conf/test_dbcan.config'                }
     test_eggnog               { includeConfig 'conf/test_eggnog.config'               }
     test_eukulele             { includeConfig 'conf/test_eukulele.config'             }
     test_kofamscan            { includeConfig 'conf/test_kofamscan.config'            }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -367,6 +367,18 @@
                     "fa_icon": "fas fa-link",
                     "hidden": true
                 },
+                "skip_dbcan": {
+                    "type": "boolean",
+                    "description": "If enabled, skips dbCAN CAZyme annotation.",
+                    "fa_icon": "fas fa-forward"
+                },
+                "dbcan_dbpath": {
+                    "type": "string",
+                    "default": "dbcan",
+                    "description": "Specify the dbCAN database path.",
+                    "fa_icon": "far fa-file-code",
+                    "help_text": "The dbCAN CAZyme database will be downloaded to this directory if it doesn't already exist there."
+                },
                 "hmmdir": {
                     "type": "string",
                     "default": null,

--- a/subworkflows/local/dbcan/main.nf
+++ b/subworkflows/local/dbcan/main.nf
@@ -1,0 +1,28 @@
+//
+// Run dbCAN CAZyme annotation on called ORFs, first optionally downloading the required database
+//
+
+include { RUNDBCAN_DATABASE         } from '../../../modules/nf-core/rundbcan/database/main'
+include { RUNDBCAN_CAZYMEANNOTATION } from '../../../modules/nf-core/rundbcan/cazymeannotation/main'
+include { DBCAN_FORMAT              } from '../../../modules/local/dbcan/format/main'
+include { DBCAN_SUM                 } from '../../../modules/local/dbcan/sum/main'
+
+workflow DBCAN {
+    take:
+    faa
+    collect_fcs
+
+    main:
+
+    RUNDBCAN_DATABASE()
+
+    RUNDBCAN_CAZYMEANNOTATION(faa, RUNDBCAN_DATABASE.out.dbcan_db)
+
+    DBCAN_FORMAT(RUNDBCAN_CAZYMEANNOTATION.out.cazyme_annotation)
+
+    DBCAN_SUM(DBCAN_FORMAT.out.dbcantsv, collect_fcs)
+
+    emit:
+    cazyme_annotation = DBCAN_FORMAT.out.dbcantsv
+    sumtable          = DBCAN_SUM.out.dbcan_summary
+}

--- a/subworkflows/local/dbcan/meta.yml
+++ b/subworkflows/local/dbcan/meta.yml
@@ -1,0 +1,36 @@
+name: dbcan
+description: Runs dbCAN CAZyme annotation on called ORFs and summarizes the results
+keywords:
+  - dbcan
+  - cazyme
+  - functional annotation
+  - protein sequences
+components:
+  - rundbcan/database
+  - rundbcan/cazymeannotation
+  - dbcan/format
+  - dbcan/sum
+input:
+  - faa:
+      type: file
+      description: Protein sequences in FASTA format
+      pattern: "*.{faa,fasta}"
+  - collect_fcs:
+      type: file
+      description: Feature count files
+      pattern: "*.counts.tsv.gz"
+output:
+  - cazyme_annotation:
+      type: file
+      description: Reformatted dbCAN CAZyme annotation TSV output file
+      pattern: "*.dbcan.tsv.gz"
+  - sumtable:
+      type: file
+      description: Summarized dbCAN CAZyme annotation results
+      pattern: "*.dbcan_summary.tsv.gz"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+authors:
+  - "@erikrikarddaniel"

--- a/workflows/metatdenovo.nf
+++ b/workflows/metatdenovo.nf
@@ -33,6 +33,7 @@ include { PROKKA_SUBSETS          } from '../subworkflows/local/prokka/subsets/'
 include { FASTQC_TRIMGALORE       } from '../subworkflows/local/fastqc/trimgalore/'
 include { PRODIGAL                } from '../subworkflows/local/prodigal/'
 include { KOFAMSCAN               } from '../subworkflows/local/kofamscan/'
+include { DBCAN                   } from '../subworkflows/local/dbcan/'
 include { TRANSDECODER            } from '../subworkflows/local/transdecoder/'
 include { PIPELINE_INITIALISATION } from '../subworkflows/local/utils_nfcore_metatdenovo_pipeline'
 include { PIPELINE_COMPLETION     } from '../subworkflows/local/utils_nfcore_metatdenovo_pipeline'
@@ -528,6 +529,14 @@ workflow METATDENOVO {
         ch_kofamscan = ch_protein.map { meta, protein -> [ meta, protein ] }
         KOFAMSCAN( ch_kofamscan, ch_fcs_for_summary, params.kofam_ko_list_url, params.kofam_profiles_url )
         ch_merge_tables = ch_merge_tables.mix ( KOFAMSCAN.out.kofamscan_summary.map { _meta, tsv -> tsv } )
+    }
+
+    //
+    // SUBWORKFLOW: run dbCAN CAZyme annotation on the ORF-called amino acid sequences
+    //
+    if( !params.skip_dbcan ) {
+        DBCAN( ch_protein, ch_fcs_for_summary )
+        ch_merge_tables = ch_merge_tables.mix ( DBCAN.out.sumtable.map { _meta, tsv -> tsv } )
     }
 
     // set up contig channel to use in TransRate


### PR DESCRIPTION
<!--
# nf-core/metatdenovo pull request

Many thanks for contributing to nf-core/metatdenovo!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/metatdenovo/tree/master/docs/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/metatdenovo/tree/master/docs/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/metatdenovo _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

## Description

Addresses #60 and #430 (duplicates of each other, both requesting dbCAN-based CAZyme annotation).

- Adds a new `DBCAN` subworkflow (`RUNDBCAN_DATABASE` -> `RUNDBCAN_CAZYMEANNOTATION` -> `DBCAN_FORMAT` -> `DBCAN_SUM`), matching the shape of the existing `EGGNOG`/`KOFAMSCAN` subworkflows exactly, wired in on by default (`--skip_dbcan`/`--dbcan_dbpath`), same as eggnog/kofamscan/eukulele.
- Installs the official `rundbcan/database` and `rundbcan/cazymeannotation` nf-core/modules. We only run protein-mode CAZyme annotation, not CGC/gene-cluster analysis, so `RUNDBCAN_DATABASE` is patched to add `--no-cgc` (skips downloading the transporter/TF/STP/sulfatase/peptidase DBs we don't use) and to drop its `tuple`/`topic: versions` output, which is incompatible with `storeDir` (`RUNDBCAN_CAZYMEANNOTATION` already reports the same dbCAN version, so nothing is lost).
- New local modules `DBCAN_FORMAT`/`DBCAN_SUM` mirror `EGGNOG_FORMAT`/`EGGNOG_SUM` and `KOFAMSCAN_FORMAT`/`KOFAMSCAN_SUM`, producing `summary_tables/<assembly>.<orfcaller>.dbcan.tsv.gz` alongside the other annotation tools' tables.
- Adds a manually-invokable `conf/test_dbcan.config` profile (`nextflow run . -profile test_dbcan,docker`), with no accompanying nf-test -- dbCAN's database download has no smaller test-data substitute available (unlike kofamscan's swappable URLs), matching the existing precedent set by `test_eggnog`/`test_eukulele`, which also have no dedicated pipeline-level nf-test.
- Verified end-to-end with a full `-stub` run of `-profile test_dbcan,docker`; `nf-core pipelines lint` (615 passed, 0 failed, 0 warnings) and `prek run -a` both clean.

Generated by Claude, reviewed by @erikrikarddaniel before opening.
