### PR TITLE
Consolidate overlapping multi-caller ORF loci before counting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added`
 
-- [#NN](https://github.com/nf-core/metatdenovo/pull/NN) - When multiple `--orf_caller` values are active, merge overlapping/identical same-contig CDS calls from different callers into single loci before counting reads, producing a new `<assembly>.locus_consolidate.counts.tsv.gz` table with caller/call-count provenance columns; with a single caller active it's identical in content to that caller's own table, addresses [#463](https://github.com/nf-core/metatdenovo/issues/463) (@erikrikarddaniel)
+- [#467](https://github.com/nf-core/metatdenovo/pull/467) - When multiple `--orf_caller` values are active, merge overlapping/identical same-contig CDS calls from different callers into single loci before counting reads, producing a new `<assembly>.locus_consolidate.counts.tsv.gz` table with caller/call-count provenance columns; with a single caller active it's identical in content to that caller's own table, addresses [#463](https://github.com/nf-core/metatdenovo/issues/463) (@erikrikarddaniel)
 - [#466](https://github.com/nf-core/metatdenovo/pull/466) - Support running multiple ORF callers in a single execution, e.g. `--orf_caller prokka,transdecoder` (each caller still produces its own independent output, no cross-caller consolidation yet), addresses [#462](https://github.com/nf-core/metatdenovo/issues/462) (@erikrikarddaniel)
 - [#465](https://github.com/nf-core/metatdenovo/pull/465) - Add MetaEuk as a splice-aware `--orf_caller` alternative for eukaryotes (`--metaeuk_db`), addresses [#459](https://github.com/nf-core/metatdenovo/issues/459) (@erikrikarddaniel)
 - [#458](https://github.com/nf-core/metatdenovo/pull/458) - Add basic ORF/protein statistics from Prodigal and TransDecoder to the MultiQC report (custom content, since neither has a MultiQC-native module), addresses the rest of [#456](https://github.com/nf-core/metatdenovo/issues/456) (@erikrikarddaniel)
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
-- [#NN](https://github.com/nf-core/metatdenovo/pull/NN) - Fix validation that was supposed to reject `--orf_caller` and `--user_orfs_gff`/`--user_orfs_faa` both being set at once, but could never actually trigger (@erikrikarddaniel)
+- [#467](https://github.com/nf-core/metatdenovo/pull/467) - Fix validation that was supposed to reject `--orf_caller` and `--user_orfs_gff`/`--user_orfs_faa` both being set at once, but could never actually trigger (@erikrikarddaniel)
 - [#466](https://github.com/nf-core/metatdenovo/pull/466) - `featurecounts/*.featureCounts.tsv` output filenames now always include the ORF caller name (e.g. `SAMPLE1.prokka.featureCounts.tsv`), required so multiple simultaneous callers (see above) don't overwrite each other's per-sample counts (@erikrikarddaniel)
 - [#466](https://github.com/nf-core/metatdenovo/pull/466) - Fix a crash when hmm-classification finds zero hits for a given ORF caller/hmm-file combination (@erikrikarddaniel)
 - [#458](https://github.com/nf-core/metatdenovo/pull/458) - Fix Prokka stats in the MultiQC report colliding under a single "strain" sample name on any assembly with more than one `prokka_batchsize` chunk, addresses part of [#456](https://github.com/nf-core/metatdenovo/issues/456) (@erikrikarddaniel)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added`
 
+- [#NN](https://github.com/nf-core/metatdenovo/pull/NN) - When multiple `--orf_caller` values are active, merge overlapping/identical same-contig CDS calls from different callers into single loci before counting reads, producing a new `<assembly>.locus_consolidate.counts.tsv.gz` table with caller/call-count provenance columns; with a single caller active it's identical in content to that caller's own table, addresses [#463](https://github.com/nf-core/metatdenovo/issues/463) (@erikrikarddaniel)
 - [#466](https://github.com/nf-core/metatdenovo/pull/466) - Support running multiple ORF callers in a single execution, e.g. `--orf_caller prokka,transdecoder` (each caller still produces its own independent output, no cross-caller consolidation yet), addresses [#462](https://github.com/nf-core/metatdenovo/issues/462) (@erikrikarddaniel)
 - [#465](https://github.com/nf-core/metatdenovo/pull/465) - Add MetaEuk as a splice-aware `--orf_caller` alternative for eukaryotes (`--metaeuk_db`), addresses [#459](https://github.com/nf-core/metatdenovo/issues/459) (@erikrikarddaniel)
 - [#458](https://github.com/nf-core/metatdenovo/pull/458) - Add basic ORF/protein statistics from Prodigal and TransDecoder to the MultiQC report (custom content, since neither has a MultiQC-native module), addresses the rest of [#456](https://github.com/nf-core/metatdenovo/issues/456) (@erikrikarddaniel)
@@ -22,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
+- [#NN](https://github.com/nf-core/metatdenovo/pull/NN) - Fix validation that was supposed to reject `--orf_caller` and `--user_orfs_gff`/`--user_orfs_faa` both being set at once, but could never actually trigger (@erikrikarddaniel)
 - [#466](https://github.com/nf-core/metatdenovo/pull/466) - `featurecounts/*.featureCounts.tsv` output filenames now always include the ORF caller name (e.g. `SAMPLE1.prokka.featureCounts.tsv`), required so multiple simultaneous callers (see above) don't overwrite each other's per-sample counts (@erikrikarddaniel)
 - [#466](https://github.com/nf-core/metatdenovo/pull/466) - Fix a crash when hmm-classification finds zero hits for a given ORF caller/hmm-file combination (@erikrikarddaniel)
 - [#458](https://github.com/nf-core/metatdenovo/pull/458) - Fix Prokka stats in the MultiQC report colliding under a single "strain" sample name on any assembly with more than one `prokka_batchsize` chunk, addresses part of [#456](https://github.com/nf-core/metatdenovo/issues/456) (@erikrikarddaniel)

--- a/CITATIONS.md
+++ b/CITATIONS.md
@@ -65,6 +65,10 @@
   > Liao Y, Smyth GK and Shi W. featureCounts: an efficient general-purpose program for assigning sequence reads to genomic features. Bioinformatics, 30(7):923-30, 2014
   > Liao Y, Smyth GK and Shi W. The Subread aligner: fast, accurate and scalable read mapping by seed-and-vote. Nucleic Acids Research, 41(10):e108, 2013
 
+- [BEDTools](https://github.com/arq5x/bedtools2)
+
+  > Quinlan AR, Hall IM. BEDTools: a flexible suite of utilities for comparing genomic features. Bioinformatics. 2010 Mar 15;26(6):841-2. doi: 10.1093/bioinformatics/btq033. Epub 2010 Jan 28. PubMed PMID: 20110278; PubMed Central PMCID: PMC2832824.
+
 - [Eggnog](https://github.com/eggnogdb/eggnog-mapper)
 
   > Cantalapiedra C, Hernandez-Plaza A, Letunic I, Bork P, Huerta-Cepas J.

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -289,6 +289,15 @@ process {
         ext.prefix = { "${meta.id}.merged" }
     }
 
+    withName: COLLECT_LOCUS_CONSOLIDATE {
+        publishDir = [
+            path: { "${params.outdir}/summary_tables" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
+            pattern: "*.gz"
+        ]
+    }
+
     withName: 'HMMER_HMMSEARCH' {
         publishDir = [
             path: { "${params.outdir}/hmmer" },

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -280,6 +280,15 @@ process {
         ]
     }
 
+    withName: 'BEDTOOLS_MERGE' {
+        // -s: strand-specific merging, so opposite-strand overlaps (different genes) stay
+        // separate. -c 6,4,4 -o distinct,distinct,count: collapse the BED strand column, the
+        // distinct "<caller>:<ID>" contributor names, and a count of them -- see
+        // FORMAT_LOCUS_CONSOLIDATE, which parses exactly this 6-column shape.
+        ext.args   = '-s -c 6,4,4 -o distinct,distinct,count'
+        ext.prefix = { "${meta.id}.merged" }
+    }
+
     withName: 'HMMER_HMMSEARCH' {
         publishDir = [
             path: { "${params.outdir}/hmmer" },

--- a/conf/test_metaeuk_transdecoder.config
+++ b/conf/test_metaeuk_transdecoder.config
@@ -1,0 +1,50 @@
+/*
+========================================================================================
+    Nextflow config file for running minimal tests
+========================================================================================
+    Defines input files and everything required to run a fast and simple pipeline test.
+
+    Use as follows:
+        nextflow run nf-core/metatdenovo -profile test_metaeuk_transdecoder,<docker/singularity>
+
+----------------------------------------------------------------------------------------
+*/
+
+process {
+    resourceLimits = [
+        cpus: 4,
+        memory: '15.GB',
+        time: '1.h'
+    ]
+
+    // TransDecoder's start-codon refinement step trains a position-weight matrix from the
+    // longest candidate ORFs in the assembly; the RPL28 test data's tiny 2-contig assembly
+    // doesn't have enough candidates for that training step and crashes
+    // ("Error, len(target_sequence)=33 and pwm length = 0"). --no_refine_starts skips it.
+    // Scoped to this profile only -- production runs and every other TransDecoder-using test
+    // profile keep the default (on) behavior.
+    withName: 'TRANSDECODER_PREDICT' {
+        ext.args = '--no_refine_starts'
+    }
+}
+
+params {
+    config_profile_name        = 'Test profile for multiple ORF callers (metaeuk + transdecoder)'
+    config_profile_description = 'Minimal eukaryotic (RPL28) test dataset to check locus consolidation of overlapping multi-caller ORFs'
+
+    // Input data
+    input      = params.pipelines_testdata_base_path + 'metatdenovo/samplesheet/samplesheet_metaeuk.csv'
+    metaeuk_db = params.pipelines_testdata_base_path + 'metatdenovo/test_data/metaeuk/rpl28_reference_db.faa'
+
+    // Params
+    assembler  = 'megahit'
+    // MetaEuk (splice-aware) and TransDecoder (not splice-aware) calling the same real RPL28
+    // gene via different coordinate footprints on the same co-assembled contig is exactly the
+    // same-contig, cross-caller overlap scenario #463's locus consolidation exists to handle.
+    orf_caller = 'metaeuk,transdecoder'
+
+    skip_eukulele  = true
+    skip_eggnog    = true
+    skip_kofamscan = true
+    skip_dbcan     = true
+}

--- a/docs/output.md
+++ b/docs/output.md
@@ -256,6 +256,12 @@ Quantification of CDS features with `featureCounts` from the [subread](https://s
   - `*.featureCounts.tsv.summar`: summary statistics
 - `summary_tables/`
   - `<assembly_name>.<orfcaller_name>.counts.tsv.gz`: reformatted count data
+  - `<assembly_name>.locus_consolidate.counts.tsv.gz`: when multiple `--orf_caller` values are
+    active, overlapping/identical same-contig CDS calls from different callers are merged into
+    single loci before counting, so a read supporting one real gene isn't counted once per caller
+    that called it. Same columns as the per-caller tables above, plus `callers` (which caller(s)
+    contributed to the locus) and `n_calls` (how many independent calls were merged). With a single
+    caller active, this table is identical in content to that caller's own table above.
 
 </details>
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -156,7 +156,9 @@ Run `metaeuk databases -h` for the full list.
 #### Running more than one ORF caller
 
 `--orf_caller` also accepts a comma-separated list, e.g. `--orf_caller prokka,transdecoder`, to run more than one caller in the same execution -- useful for mixed prokaryote/eukaryote communities.
-Each active caller runs independently and produces its own complete set of output (GFF, protein FASTA, `summary_tables/<assembly>.<caller>.*`) under its own name, exactly as if it had been run alone; there is currently no consolidation of results across callers.
+Each active caller still runs independently and produces its own complete set of output (GFF, protein FASTA, `summary_tables/<assembly>.<caller>.*`) under its own name, exactly as if it had been run alone.
+In addition, `summary_tables/<assembly>.locus_consolidate.counts.tsv.gz` merges overlapping/identical same-contig CDS calls from different callers into single loci before counting reads, so a read supporting one real gene isn't counted once per caller that called it; see [Output docs](output.md) for details.
+Cross-contig consolidation is not performed.
 
 #### Provide your own ORFs
 

--- a/modules.json
+++ b/modules.json
@@ -26,6 +26,16 @@
                         "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
                         "installed_by": ["modules"]
                     },
+                    "bedtools/merge": {
+                        "branch": "master",
+                        "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
+                        "installed_by": ["modules"]
+                    },
+                    "bedtools/sort": {
+                        "branch": "master",
+                        "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
+                        "installed_by": ["modules"]
+                    },
                     "cat/fastq": {
                         "branch": "master",
                         "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",

--- a/modules/local/collect/locus_consolidate/environment.yml
+++ b/modules/local/collect/locus_consolidate/environment.yml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - conda-forge::r-base=4.5.3
+  - conda-forge::r-dplyr=1.2.1
+  - conda-forge::r-readr=2.2.0
+  - conda-forge::r-purrr=1.2.2
+  - conda-forge::r-tidyr=1.3.2
+  - conda-forge::r-stringi=1.8.7
+  - conda-forge::r-stringr=1.6.0
+  - conda-forge::r-tidyverse=2.0.0
+  - conda-forge::r-data.table=1.17.8
+  - conda-forge::r-dtplyr=1.3.3

--- a/modules/local/collect/locus_consolidate/main.nf
+++ b/modules/local/collect/locus_consolidate/main.nf
@@ -1,0 +1,95 @@
+process COLLECT_LOCUS_CONSOLIDATE {
+    tag "$meta.id"
+    label 'process_high'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/4b/4b997e8d619c30e5ea23a08d9fb7e4b0c9b441f3187b64d65ff1c0df5e12bba0/data' :
+        'community.wave.seqera.io/library/r-base_r-r.utils_r-dplyr_r-readr_pruned:b59bb1a4cfb1196e' }"
+
+    input:
+    tuple val(meta), path(inputfiles), path(provenance)
+
+    output:
+    tuple val(meta), path("*.counts.tsv.gz"), emit: counts
+    path "versions.yml"                     , emit: versions, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    #!/usr/bin/env Rscript
+
+    library(data.table)
+    library(dtplyr)
+    library(readr)
+    library(dplyr)
+    library(stringr)
+
+    setDTthreads($task.cpus)
+
+    # A multi-exon locus whose ID was inherited from a single caller (see FORMAT_LOCUS_CONSOLIDATE)
+    # has one provenance row per exon segment, all identical (same caller, same n_calls) -- collapse
+    # to one row per ID or the join below fans out and duplicates that locus's counts rows.
+    provenance <- fread('${provenance}', sep = '\\t') %>% distinct()
+
+    tibble(f = Sys.glob('*.featureCounts.tsv')) %>%
+        mutate(
+            d = purrr::map(
+                f,
+                function(file) {
+                    fread(file, sep = '\\t', skip = 1) %>%
+                        melt(measure.vars = c(ncol(.)), variable.name = 'sample', value.name = 'count') %>%
+                        lazy_dt() %>%
+                        filter(count > 0) %>%
+                        mutate(
+                            sample = str_remove(sample, '.sorted.bam'),
+                            r = count/Length
+                        ) %>%
+                        rename(orf = Geneid, chr = Chr, start = Start, end = End, strand = Strand, length = Length) %>%
+                        group_by(sample) %>%
+                        mutate(tpm = r/sum(r) * 1e6) %>% ungroup() %>%
+                        select(-r) %>%
+                        as_tibble()
+                }
+            )
+        ) %>%
+        tidyr::unnest(d) %>%
+        # Transdecoder appends "cds." to ORF IDs in the gff file, but does not in the fasta file. Remove to make compatible between tables.
+        mutate(orf = str_remove(orf, '^cds\\\\.')) %>%
+        select(-f) %>%
+        # Per-locus provenance: which caller(s) contributed and how many independent calls were merged.
+        left_join(provenance, by = c('orf' = 'ID')) %>%
+        write_tsv("${prefix}.counts.tsv.gz")
+
+        writeLines(
+            c(
+                "\\"${task.process}\\":",
+                paste0("    R: ", paste0(R.Version()[c("major","minor")], collapse = ".")),
+                paste0("    dplyr: ", packageVersion('dplyr')),
+                paste0("    readr: ", packageVersion('readr')),
+                paste0("    stringr: ", packageVersion('stringr')),
+                paste0("    dtplyr: ", packageVersion('dtplyr')),
+                paste0("    data.table: ", packageVersion('data.table'))
+            ),
+            "versions.yml"
+        )
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.counts.tsv
+    gzip ${prefix}.counts.tsv
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        R: 4.1.0
+        dplyr: 1.0.7
+        dtplyr: 1.1.0
+        data.table: 1.14.0
+    END_VERSIONS
+    """
+}

--- a/modules/local/collect/locus_consolidate/meta.yml
+++ b/modules/local/collect/locus_consolidate/meta.yml
@@ -1,0 +1,38 @@
+name: "collect_locus_consolidate"
+description: Collects per-sample featureCounts output against the locus-consolidated GFF
+  into one TPM-normalized table, joined with FORMAT_LOCUS_CONSOLIDATE's provenance table
+  (which caller(s) contributed to each locus, and how many independent calls were merged)
+keywords:
+  - counts
+  - tpm
+  - locus consolidation
+  - provenance
+input:
+  - meta:
+      type: map
+      description: Groovy Map containing sample information
+  - inputfiles:
+      type: file
+      description: One `*.featureCounts.tsv` file per sample, counted against the
+        locus-consolidated GFF
+      pattern: "*.featureCounts.tsv"
+  - provenance:
+      type: file
+      description: Per-locus provenance table from FORMAT_LOCUS_CONSOLIDATE (ID, callers, n_calls)
+      pattern: "*.provenance.tsv.gz"
+output:
+  - meta:
+      type: map
+      description: Groovy Map containing sample information
+  - counts:
+      type: file
+      description: TPM-normalized counts table with provenance columns appended
+      pattern: "*.counts.tsv.gz"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+authors:
+  - "@erikrikarddaniel"
+maintainers:
+  - "@erikrikarddaniel"

--- a/modules/local/format/gff2bed/environment.yml
+++ b/modules/local/format/gff2bed/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - conda-forge::gzip=1.11

--- a/modules/local/format/gff2bed/main.nf
+++ b/modules/local/format/gff2bed/main.nf
@@ -1,0 +1,48 @@
+process FORMAT_GFF2BED {
+    tag "$meta.id"
+    label 'process_low'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/gzip:1.11':
+        'biocontainers/gzip:1.11' }"
+
+    input:
+    tuple val(meta), path(gff)
+
+    output:
+    tuple val(meta), path("${prefix}.bed"), emit: bed
+    tuple val("${task.process}"), val('gzip'), eval('gzip --version  2>&1 | grep "^gzip" | sed "s/^gzip \\([0-9.]\\+\\).*/\\1/"'), emit: versions_gzip, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    prefix    = task.ext.prefix ?: "${meta.id}"
+    cat_input = gff =~ /\.gz$/ ? "gunzip -c ${gff}" : "cat ${gff}"
+
+    // BED is 0-based half-open, GFF is 1-based inclusive: start shifts by one, end is unchanged.
+    // The "(^|;)ID=" anchor (rather than a bare "ID=") avoids matching inside MetaEuk's
+    // Target_ID=/TCS_ID= attributes, which also contain the substring "ID=".
+    // The "cds." prefix strip mirrors COLLECT_FEATURECOUNTS's existing TransDecoder-ID normalization
+    // (modules/local/collect/featurecounts/main.nf), so a locus this caller is the sole contributor to
+    // inherits an ID matching that caller's own per-caller counts table exactly.
+    """
+    $cat_input \\
+        | awk -v caller="${meta.caller}" 'BEGIN{FS="\\t"; OFS="\\t"}
+            \$3=="CDS" {
+                match(\$9, /(^|;)ID=[^;]+/)
+                id = substr(\$9, RSTART, RLENGTH)
+                sub(/^;?ID=/, "", id)
+                sub(/^cds\\./, "", id)
+                print \$1, \$4-1, \$5, caller":"id, 0, \$7
+            }' \\
+        > ${prefix}.bed
+    """
+
+    stub:
+    prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.bed
+    """
+}

--- a/modules/local/format/gff2bed/meta.yml
+++ b/modules/local/format/gff2bed/meta.yml
@@ -1,0 +1,33 @@
+name: "format_gff2bed"
+description: Converts one ORF caller's CDS-only GFF into a strand-aware BED6, tagging
+  each feature's name column with "<caller>:<original ID>" so multiple callers'
+  output can be concatenated and fed to bedtools merge for locus consolidation
+keywords:
+  - gff
+  - bed
+  - format
+  - locus consolidation
+input:
+  - meta:
+      type: map
+      description: Groovy Map containing sample information, including `caller`
+  - gff:
+      type: file
+      description: One ORF caller's CDS-containing GFF output file
+      pattern: "*.gff{3,.gz,}"
+output:
+  - meta:
+      type: map
+      description: Groovy Map containing sample information
+  - bed:
+      type: file
+      description: BED6 file, one row per CDS feature, name column "<caller>:<ID>"
+      pattern: "*.bed"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+authors:
+  - "@erikrikarddaniel"
+maintainers:
+  - "@erikrikarddaniel"

--- a/modules/local/format/locus_consolidate/environment.yml
+++ b/modules/local/format/locus_consolidate/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - conda-forge::gzip=1.11

--- a/modules/local/format/locus_consolidate/main.nf
+++ b/modules/local/format/locus_consolidate/main.nf
@@ -1,0 +1,69 @@
+process FORMAT_LOCUS_CONSOLIDATE {
+    tag "$meta.id"
+    label 'process_low'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/gzip:1.11':
+        'biocontainers/gzip:1.11' }"
+
+    input:
+    tuple val(meta), path(merged_bed)
+
+    output:
+    tuple val(meta), path("${prefix}.gff.gz")        , emit: gff
+    tuple val(meta), path("${prefix}.provenance.tsv.gz"), emit: provenance
+    tuple val("${task.process}"), val('gzip'), eval('gzip --version  2>&1 | grep "^gzip" | sed "s/^gzip \\([0-9.]\\+\\).*/\\1/"'), emit: versions_gzip, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    prefix = task.ext.prefix ?: "${meta.id}"
+
+    // bedtools merge output (see BEDTOOLS_MERGE's ext.args): chr, start (0-based), end, strand,
+    // distinct "<caller>:<original ID>" names, count. ID-inheritance rule: a locus with exactly one
+    // distinct contributor inherits that contributor's own original ID verbatim, so a single-caller
+    // run is byte-identical to that caller's own per-caller GFF; a locus with several distinct
+    // contributors gets a fresh coordinate-derived ID instead.
+    """
+    awk 'BEGIN {
+            FS = OFS = "\\t"
+            print "ID", "callers", "n_calls" | "gzip -c > ${prefix}.provenance.tsv.gz"
+        }
+        {
+            start = \$2 + 1
+            end   = \$3
+            strand = \$4
+            n = split(\$5, names, ",")
+
+            if (n == 1) {
+                sep = index(names[1], ":")
+                id  = substr(names[1], sep + 1)
+                callers = substr(names[1], 1, sep - 1)
+            } else {
+                id = "locus_" \$1 "_" start "_" end "_" strand
+                delete seen
+                callers = ""
+                for (i = 1; i <= n; i++) {
+                    sep    = index(names[i], ":")
+                    caller = substr(names[i], 1, sep - 1)
+                    if (!(caller in seen)) {
+                        seen[caller] = 1
+                        callers = (callers == "" ? caller : callers "," caller)
+                    }
+                }
+            }
+
+            print \$1, "locus_consolidate", "CDS", start, end, ".", strand, ".", "ID="id | "gzip -c > ${prefix}.gff.gz"
+            print id, callers, \$6 | "gzip -c > ${prefix}.provenance.tsv.gz"
+        }' ${merged_bed}
+    """
+
+    stub:
+    prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    gzip -c /dev/null > ${prefix}.gff.gz
+    gzip -c /dev/null > ${prefix}.provenance.tsv.gz
+    """
+}

--- a/modules/local/format/locus_consolidate/meta.yml
+++ b/modules/local/format/locus_consolidate/meta.yml
@@ -1,0 +1,42 @@
+name: "format_locus_consolidate"
+description: Turns bedtools-merge output (strand-aware merged CDS intervals from multiple
+  ORF callers) into a consolidated GFF, applying the ID-inheritance rule -- a locus with a
+  single distinct contributor keeps that contributor's own original ID, a locus with
+  several distinct contributors gets a fresh coordinate-derived ID -- plus a separate
+  provenance table recording which caller(s) contributed to each locus and how many
+  independent calls it received
+keywords:
+  - gff
+  - bed
+  - format
+  - locus consolidation
+input:
+  - meta:
+      type: map
+      description: Groovy Map containing sample information
+  - merged_bed:
+      type: file
+      description: >
+        bedtools merge output over all active callers' CDS intervals, 6 columns:
+        chr, start (0-based), end, strand, distinct "<caller>:<original ID>" names, count
+      pattern: "*.bed"
+output:
+  - meta:
+      type: map
+      description: Groovy Map containing sample information
+  - gff:
+      type: file
+      description: Consolidated CDS GFF, one row per merged locus
+      pattern: "*.gff.gz"
+  - provenance:
+      type: file
+      description: Per-locus provenance table (ID, callers, n_calls)
+      pattern: "*.provenance.tsv.gz"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+authors:
+  - "@erikrikarddaniel"
+maintainers:
+  - "@erikrikarddaniel"

--- a/modules/nf-core/bedtools/merge/environment.yml
+++ b/modules/nf-core/bedtools/merge/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::bedtools=2.31.1

--- a/modules/nf-core/bedtools/merge/main.nf
+++ b/modules/nf-core/bedtools/merge/main.nf
@@ -1,0 +1,39 @@
+process BEDTOOLS_MERGE {
+    tag "${meta.id}"
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://depot.galaxyproject.org/singularity/bedtools:2.31.1--hf5e1c6e_0'
+        : 'quay.io/biocontainers/bedtools:2.31.1--hf5e1c6e_0'}"
+
+    input:
+    tuple val(meta), path(bed)
+
+    output:
+    tuple val(meta), path('*.bed'), emit: bed
+    tuple val("${task.process}"), val('bedtools'), eval("bedtools --version | sed -e 's/bedtools v//g'"), topic: versions, emit: versions_bedtools
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    if ("${bed}" == "${prefix}.bed") {
+        error("Input and output names are the same, use \"task.ext.prefix\" to disambiguate!")
+    }
+    """
+    bedtools \\
+        merge \\
+        -i ${bed} \\
+        ${args} \\
+        > ${prefix}.bed
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.bed
+    """
+}

--- a/modules/nf-core/bedtools/merge/meta.yml
+++ b/modules/nf-core/bedtools/merge/meta.yml
@@ -1,0 +1,67 @@
+name: bedtools_merge
+description: combines overlapping or “book-ended” features in an interval file into
+  a single feature which spans all of the combined features.
+keywords:
+  - bed
+  - merge
+  - bedtools
+  - overlapped bed
+tools:
+  - bedtools:
+      description: |
+        A set of tools for genomic analysis tasks, specifically enabling genome arithmetic (merge, count, complement) on various file types.
+      documentation: https://bedtools.readthedocs.io/en/latest/content/tools/merge.html
+      licence: ["MIT"]
+      identifier: biotools:bedtools
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - bed:
+        type: file
+        description: Input BED file
+        pattern: "*.{bed}"
+        ontologies: []
+output:
+  bed:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.bed":
+          type: file
+          description: Overlapped bed file with combined features
+          pattern: "*.{bed}"
+          ontologies: []
+  versions_bedtools:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - bedtools:
+          type: string
+          description: The name of the tool
+      - "bedtools --version | sed -e 's/bedtools v//g'":
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - bedtools:
+          type: string
+          description: The name of the tool
+      - "bedtools --version | sed -e 's/bedtools v//g'":
+          type: eval
+          description: The expression to obtain the version of the tool
+authors:
+  - "@edmundmiller"
+  - "@sruthipsuresh"
+  - "@drpatelh"
+maintainers:
+  - "@edmundmiller"
+  - "@sruthipsuresh"
+  - "@drpatelh"

--- a/modules/nf-core/bedtools/merge/tests/main.nf.test
+++ b/modules/nf-core/bedtools/merge/tests/main.nf.test
@@ -1,0 +1,34 @@
+nextflow_process {
+
+    name "Test Process BEDTOOLS_MERGE"
+    script "../main.nf"
+    config "./nextflow.config"
+    process "BEDTOOLS_MERGE"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "bedtools"
+    tag "bedtools/merge"
+
+    test("test_bedtools_merge") {
+
+        when {
+            process {
+                """
+                input[0] = [ [ id:'test'],
+                file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/bed/test.bed', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+}

--- a/modules/nf-core/bedtools/merge/tests/main.nf.test.snap
+++ b/modules/nf-core/bedtools/merge/tests/main.nf.test.snap
@@ -1,0 +1,43 @@
+{
+    "test_bedtools_merge": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_out.bed:md5,0cf6ed2b6f470cd44a247da74ca4fe4e"
+                    ]
+                ],
+                "1": [
+                    [
+                        "BEDTOOLS_MERGE",
+                        "bedtools",
+                        "2.31.1"
+                    ]
+                ],
+                "bed": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_out.bed:md5,0cf6ed2b6f470cd44a247da74ca4fe4e"
+                    ]
+                ],
+                "versions_bedtools": [
+                    [
+                        "BEDTOOLS_MERGE",
+                        "bedtools",
+                        "2.31.1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-01-21T11:32:43.625892195"
+    }
+}

--- a/modules/nf-core/bedtools/merge/tests/nextflow.config
+++ b/modules/nf-core/bedtools/merge/tests/nextflow.config
@@ -1,0 +1,7 @@
+process {
+
+    withName: BEDTOOLS_MERGE {
+        ext.prefix = { "${meta.id}_out" }
+    }
+
+}

--- a/modules/nf-core/bedtools/sort/environment.yml
+++ b/modules/nf-core/bedtools/sort/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::bedtools=2.31.1

--- a/modules/nf-core/bedtools/sort/main.nf
+++ b/modules/nf-core/bedtools/sort/main.nf
@@ -1,0 +1,44 @@
+process BEDTOOLS_SORT {
+    tag "${meta.id}"
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://depot.galaxyproject.org/singularity/bedtools:2.31.1--hf5e1c6e_0'
+        : 'quay.io/biocontainers/bedtools:2.31.1--hf5e1c6e_0'}"
+
+    input:
+    tuple val(meta), path(intervals)
+    path genome_file
+
+    output:
+    tuple val(meta), path("*.${extension}"), emit: sorted
+    tuple val("${task.process}"), val('bedtools'), eval("bedtools --version | sed -e 's/bedtools v//g'"), topic: versions, emit: versions_bedtools
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def genome_cmd = genome_file ? "-g ${genome_file}" : ""
+    extension = task.ext.suffix ?: intervals.extension
+    if ("${intervals}" == "${prefix}.${extension}") {
+        error("Input and output names are the same, use \"task.ext.prefix\" to disambiguate!")
+    }
+    """
+    bedtools \\
+        sort \\
+        -i ${intervals} \\
+        ${genome_cmd} \\
+        ${args} \\
+        > ${prefix}.${extension}
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    extension = task.ext.suffix ?: intervals.extension
+    """
+    touch ${prefix}.${extension}
+    """
+}

--- a/modules/nf-core/bedtools/sort/meta.yml
+++ b/modules/nf-core/bedtools/sort/meta.yml
@@ -1,0 +1,76 @@
+name: bedtools_sort
+description: Sorts a feature file by chromosome and other criteria.
+keywords:
+  - bed
+  - sort
+  - bedtools
+  - chromosome
+tools:
+  - bedtools:
+      description: |
+        A set of tools for genomic analysis tasks, specifically enabling genome arithmetic (merge, count, complement) on various file types.
+      documentation: https://bedtools.readthedocs.io/en/latest/content/tools/sort.html
+      licence: ["MIT"]
+      identifier: biotools:bedtools
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - intervals:
+        type: file
+        description: BED/BEDGRAPH
+        pattern: "*.{bed|bedGraph}"
+        ontologies: []
+  - genome_file:
+      type: file
+      description: |
+        Optional reference genome 2 column file that defines the expected chromosome order.
+      pattern: "*.{fai,txt,chromsizes}"
+      ontologies: []
+output:
+  sorted:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.${extension}":
+          type: file
+          description: Sorted output file
+          pattern: "*.${extension}"
+          ontologies: []
+  versions_bedtools:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - bedtools:
+          type: string
+          description: The name of the tool
+      - "bedtools --version | sed -e 's/bedtools v//g'":
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - bedtools:
+          type: string
+          description: The name of the tool
+      - "bedtools --version | sed -e 's/bedtools v//g'":
+          type: eval
+          description: The expression to obtain the version of the tool
+authors:
+  - "@edmundmiller"
+  - "@sruthipsuresh"
+  - "@drpatelh"
+  - "@chris-cheshire"
+  - "@adamrtalbot"
+maintainers:
+  - "@edmundmiller"
+  - "@sruthipsuresh"
+  - "@drpatelh"
+  - "@chris-cheshire"
+  - "@adamrtalbot"

--- a/modules/nf-core/bedtools/sort/tests/main.nf.test
+++ b/modules/nf-core/bedtools/sort/tests/main.nf.test
@@ -1,0 +1,58 @@
+nextflow_process {
+
+    name "Test Process BEDTOOLS_SORT"
+    script "../main.nf"
+    config "./nextflow.config"
+    process "BEDTOOLS_SORT"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "bedtools"
+    tag "bedtools/sort"
+
+    test("test_bedtools_sort") {
+
+        when {
+            process {
+                """
+                input[0] = [ [ id:'test'],
+                 file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/bed/test.bed', checkIfExists: true)
+                ]
+                input[1] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+
+    test("test_bedtools_sort_with_genome") {
+
+        when {
+            process {
+                """
+                input[0] = [ [ id:'test'],
+                 file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/bed/test.bed', checkIfExists: true)
+                ]
+                input[1] = file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.fai', checkIfExists: true)
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+}

--- a/modules/nf-core/bedtools/sort/tests/main.nf.test.snap
+++ b/modules/nf-core/bedtools/sort/tests/main.nf.test.snap
@@ -1,0 +1,84 @@
+{
+    "test_bedtools_sort_with_genome": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_out.testtext:md5,fe4053cf4de3aebbdfc3be2efb125a74"
+                    ]
+                ],
+                "1": [
+                    [
+                        "BEDTOOLS_SORT",
+                        "bedtools",
+                        "2.31.1"
+                    ]
+                ],
+                "sorted": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_out.testtext:md5,fe4053cf4de3aebbdfc3be2efb125a74"
+                    ]
+                ],
+                "versions_bedtools": [
+                    [
+                        "BEDTOOLS_SORT",
+                        "bedtools",
+                        "2.31.1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-01-21T11:43:51.322851825"
+    },
+    "test_bedtools_sort": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_out.testtext:md5,fe4053cf4de3aebbdfc3be2efb125a74"
+                    ]
+                ],
+                "1": [
+                    [
+                        "BEDTOOLS_SORT",
+                        "bedtools",
+                        "2.31.1"
+                    ]
+                ],
+                "sorted": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_out.testtext:md5,fe4053cf4de3aebbdfc3be2efb125a74"
+                    ]
+                ],
+                "versions_bedtools": [
+                    [
+                        "BEDTOOLS_SORT",
+                        "bedtools",
+                        "2.31.1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-01-21T11:43:43.827943601"
+    }
+}

--- a/modules/nf-core/bedtools/sort/tests/nextflow.config
+++ b/modules/nf-core/bedtools/sort/tests/nextflow.config
@@ -1,0 +1,8 @@
+process {
+
+    withName: BEDTOOLS_SORT {
+            ext.prefix = { "${meta.id}_out" }
+            ext.suffix = "testtext"
+    }
+
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -245,6 +245,7 @@ profiles {
     test_megahit_prokka_transdecoder { includeConfig 'conf/test_megahit_prokka_transdecoder.config' }
     test_megahit_transdecoder        { includeConfig 'conf/test_megahit_transdecoder.config'        }
     test_metaeuk                     { includeConfig 'conf/test_metaeuk.config'                     }
+    test_metaeuk_transdecoder        { includeConfig 'conf/test_metaeuk_transdecoder.config'        }
     test_dbcan                       { includeConfig 'conf/test_dbcan.config'                       }
     test_eggnog                      { includeConfig 'conf/test_eggnog.config'                      }
     test_eukulele                    { includeConfig 'conf/test_eukulele.config'                    }

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -11,10 +11,24 @@
                 "BBMAP_INDEX": {
                     "bbmap": 39.18
                 },
+                "BEDTOOLS_MERGE": {
+                    "bedtools": "2.31.1"
+                },
+                "BEDTOOLS_SORT": {
+                    "bedtools": "2.31.1"
+                },
                 "CAT_FASTQ": {
                     "cat": 9.5
                 },
                 "COLLECT_FEATURECOUNTS": {
+                    "R": "4.5.3",
+                    "dplyr": "1.2.1",
+                    "readr": "2.2.0",
+                    "stringr": "1.6.0",
+                    "dtplyr": "1.3.3",
+                    "data.table": "1.17.8"
+                },
+                "COLLECT_LOCUS_CONSOLIDATE": {
                     "R": "4.5.3",
                     "dplyr": "1.2.1",
                     "readr": "2.2.0",
@@ -35,6 +49,12 @@
                 },
                 "FEATURECOUNTS_CDS": {
                     "subread": "2.1.1"
+                },
+                "FORMAT_GFF2BED": {
+                    "gzip": 1.11
+                },
+                "FORMAT_LOCUS_CONSOLIDATE": {
+                    "gzip": 1.11
                 },
                 "FORMAT_PRODIGAL_GFF": {
                     "gzip": 1.11
@@ -106,10 +126,16 @@
                 "bbmap/bbmap/SAMPLE2_PE.bbmap.log",
                 "bbmap/bbmap/SAMPLE3_PE_1.bbmap.log",
                 "featurecounts",
+                "featurecounts/SAMPLE1_PE.locus_consolidate.featureCounts.tsv",
+                "featurecounts/SAMPLE1_PE.locus_consolidate.featureCounts.tsv.summary",
                 "featurecounts/SAMPLE1_PE.prodigal.featureCounts.tsv",
                 "featurecounts/SAMPLE1_PE.prodigal.featureCounts.tsv.summary",
+                "featurecounts/SAMPLE2_PE.locus_consolidate.featureCounts.tsv",
+                "featurecounts/SAMPLE2_PE.locus_consolidate.featureCounts.tsv.summary",
                 "featurecounts/SAMPLE2_PE.prodigal.featureCounts.tsv",
                 "featurecounts/SAMPLE2_PE.prodigal.featureCounts.tsv.summary",
+                "featurecounts/SAMPLE3_PE_1.locus_consolidate.featureCounts.tsv",
+                "featurecounts/SAMPLE3_PE_1.locus_consolidate.featureCounts.tsv.summary",
                 "featurecounts/SAMPLE3_PE_1.prodigal.featureCounts.tsv",
                 "featurecounts/SAMPLE3_PE_1.prodigal.featureCounts.tsv.summary",
                 "hmmer",
@@ -174,6 +200,7 @@
                 "samtools/megahit.SAMPLE3_PE_1.flagstat",
                 "samtools/megahit.SAMPLE3_PE_1.idxstats",
                 "summary_tables",
+                "summary_tables/megahit.locus_consolidate.counts.tsv.gz",
                 "summary_tables/megahit.prodigal.counts.tsv.gz",
                 "summary_tables/megahit.prodigal.hmmrank.tsv.gz",
                 "summary_tables/megahit.prodigal.overall_stats.tsv.gz",
@@ -217,7 +244,7 @@
                 "sample\tn_post_trimming\tn_non_contaminated\tidxs_n_mapped\tidxs_n_unmapped\tn_feature_count"
             ]
         ],
-        "timestamp": "2026-08-19T01:55:23.755122278",
+        "timestamp": "2026-08-20T12:15:47.949097202",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"

--- a/tests/diamond.nf.test.snap
+++ b/tests/diamond.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "-profile test_diamond": {
         "content": [
-            56,
+            64,
             {
                 "BBMAP_ALIGN": {
                     "bbmap": 39.18
@@ -9,10 +9,24 @@
                 "BBMAP_INDEX": {
                     "bbmap": 39.18
                 },
+                "BEDTOOLS_MERGE": {
+                    "bedtools": "2.31.1"
+                },
+                "BEDTOOLS_SORT": {
+                    "bedtools": "2.31.1"
+                },
                 "CAT_FASTQ": {
                     "cat": 9.5
                 },
                 "COLLECT_FEATURECOUNTS": {
+                    "R": "4.5.3",
+                    "dplyr": "1.2.1",
+                    "readr": "2.2.0",
+                    "stringr": "1.6.0",
+                    "dtplyr": "1.3.3",
+                    "data.table": "1.17.8"
+                },
+                "COLLECT_LOCUS_CONSOLIDATE": {
                     "R": "4.5.3",
                     "dplyr": "1.2.1",
                     "readr": "2.2.0",
@@ -47,6 +61,12 @@
                     "tidyr": "1.3.0",
                     "readr": "2.1.4",
                     "stringr": "1.5.0"
+                },
+                "FORMAT_GFF2BED": {
+                    "gzip": 1.11
+                },
+                "FORMAT_LOCUS_CONSOLIDATE": {
+                    "gzip": 1.11
                 },
                 "FORMAT_PRODIGAL_GFF": {
                     "gzip": 1.11
@@ -129,10 +149,16 @@
                 "diamond_taxonomy/megahit.prodigal.ncbi-refseq-test.lineage.tsv.gz",
                 "diamond_taxonomy/megahit.prodigal.ncbi-refseq-test.tsv.gz",
                 "featurecounts",
+                "featurecounts/SAMPLE1_PE.locus_consolidate.featureCounts.tsv",
+                "featurecounts/SAMPLE1_PE.locus_consolidate.featureCounts.tsv.summary",
                 "featurecounts/SAMPLE1_PE.prodigal.featureCounts.tsv",
                 "featurecounts/SAMPLE1_PE.prodigal.featureCounts.tsv.summary",
+                "featurecounts/SAMPLE2_PE.locus_consolidate.featureCounts.tsv",
+                "featurecounts/SAMPLE2_PE.locus_consolidate.featureCounts.tsv.summary",
                 "featurecounts/SAMPLE2_PE.prodigal.featureCounts.tsv",
                 "featurecounts/SAMPLE2_PE.prodigal.featureCounts.tsv.summary",
+                "featurecounts/SAMPLE3_PE_1.locus_consolidate.featureCounts.tsv",
+                "featurecounts/SAMPLE3_PE_1.locus_consolidate.featureCounts.tsv.summary",
                 "featurecounts/SAMPLE3_PE_1.prodigal.featureCounts.tsv",
                 "featurecounts/SAMPLE3_PE_1.prodigal.featureCounts.tsv.summary",
                 "megahit",
@@ -186,6 +212,7 @@
                 "samtools/megahit.SAMPLE3_PE_1.flagstat",
                 "samtools/megahit.SAMPLE3_PE_1.idxstats",
                 "summary_tables",
+                "summary_tables/megahit.locus_consolidate.counts.tsv.gz",
                 "summary_tables/megahit.prodigal.counts.tsv.gz",
                 "summary_tables/megahit.prodigal.gtdb-r220-test.diamond.taxonomy.tsv.gz",
                 "summary_tables/megahit.prodigal.ncbi-refseq-test.diamond.taxonomy-taxdump.tsv.gz",
@@ -219,7 +246,7 @@
                 "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f"
             ]
         ],
-        "timestamp": "2026-08-19T02:01:44.646186519",
+        "timestamp": "2026-08-20T12:19:58.623429581",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"

--- a/tests/kofamscan.nf.test.snap
+++ b/tests/kofamscan.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "-profile test_kofamscan": {
         "content": [
-            50,
+            58,
             {
                 "BBMAP_ALIGN": {
                     "bbmap": 39.18
@@ -9,10 +9,24 @@
                 "BBMAP_INDEX": {
                     "bbmap": 39.18
                 },
+                "BEDTOOLS_MERGE": {
+                    "bedtools": "2.31.1"
+                },
+                "BEDTOOLS_SORT": {
+                    "bedtools": "2.31.1"
+                },
                 "CAT_FASTQ": {
                     "cat": 9.5
                 },
                 "COLLECT_FEATURECOUNTS": {
+                    "R": "4.5.3",
+                    "dplyr": "1.2.1",
+                    "readr": "2.2.0",
+                    "stringr": "1.6.0",
+                    "dtplyr": "1.3.3",
+                    "data.table": "1.17.8"
+                },
+                "COLLECT_LOCUS_CONSOLIDATE": {
                     "R": "4.5.3",
                     "dplyr": "1.2.1",
                     "readr": "2.2.0",
@@ -33,6 +47,12 @@
                 },
                 "FEATURECOUNTS_CDS": {
                     "subread": "2.1.1"
+                },
+                "FORMAT_GFF2BED": {
+                    "gzip": 1.11
+                },
+                "FORMAT_LOCUS_CONSOLIDATE": {
+                    "gzip": 1.11
                 },
                 "FORMAT_PRODIGAL_GFF": {
                     "gzip": 1.11
@@ -124,10 +144,16 @@
                 "bbmap/bbmap/SAMPLE2_PE.bbmap.log",
                 "bbmap/bbmap/SAMPLE3_PE_1.bbmap.log",
                 "featurecounts",
+                "featurecounts/SAMPLE1_PE.locus_consolidate.featureCounts.tsv",
+                "featurecounts/SAMPLE1_PE.locus_consolidate.featureCounts.tsv.summary",
                 "featurecounts/SAMPLE1_PE.prodigal.featureCounts.tsv",
                 "featurecounts/SAMPLE1_PE.prodigal.featureCounts.tsv.summary",
+                "featurecounts/SAMPLE2_PE.locus_consolidate.featureCounts.tsv",
+                "featurecounts/SAMPLE2_PE.locus_consolidate.featureCounts.tsv.summary",
                 "featurecounts/SAMPLE2_PE.prodigal.featureCounts.tsv",
                 "featurecounts/SAMPLE2_PE.prodigal.featureCounts.tsv.summary",
+                "featurecounts/SAMPLE3_PE_1.locus_consolidate.featureCounts.tsv",
+                "featurecounts/SAMPLE3_PE_1.locus_consolidate.featureCounts.tsv.summary",
                 "featurecounts/SAMPLE3_PE_1.prodigal.featureCounts.tsv",
                 "featurecounts/SAMPLE3_PE_1.prodigal.featureCounts.tsv.summary",
                 "kofamscan",
@@ -183,6 +209,7 @@
                 "samtools/megahit.SAMPLE3_PE_1.flagstat",
                 "samtools/megahit.SAMPLE3_PE_1.idxstats",
                 "summary_tables",
+                "summary_tables/megahit.locus_consolidate.counts.tsv.gz",
                 "summary_tables/megahit.prodigal.counts.tsv.gz",
                 "summary_tables/megahit.prodigal.kofamscan-uniq.tsv.gz",
                 "summary_tables/megahit.prodigal.kofamscan.tsv.gz",
@@ -215,7 +242,7 @@
                 "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f"
             ]
         ],
-        "timestamp": "2026-08-19T02:09:02.595401711",
+        "timestamp": "2026-08-20T12:23:05.150707866",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"

--- a/tests/megahit_prokka.nf.test.snap
+++ b/tests/megahit_prokka.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "-profile test_megahit_prokka": {
         "content": [
-            47,
+            55,
             {
                 "BBMAP_ALIGN": {
                     "bbmap": 39.18
@@ -9,10 +9,24 @@
                 "BBMAP_INDEX": {
                     "bbmap": 39.18
                 },
+                "BEDTOOLS_MERGE": {
+                    "bedtools": "2.31.1"
+                },
+                "BEDTOOLS_SORT": {
+                    "bedtools": "2.31.1"
+                },
                 "CAT_FASTQ": {
                     "cat": 9.5
                 },
                 "COLLECT_FEATURECOUNTS": {
+                    "R": "4.5.3",
+                    "dplyr": "1.2.1",
+                    "readr": "2.2.0",
+                    "stringr": "1.6.0",
+                    "dtplyr": "1.3.3",
+                    "data.table": "1.17.8"
+                },
+                "COLLECT_LOCUS_CONSOLIDATE": {
                     "R": "4.5.3",
                     "dplyr": "1.2.1",
                     "readr": "2.2.0",
@@ -43,6 +57,12 @@
                     "coreutils": 9.4,
                     "find": "4.6.0",
                     "pigz": 2.8
+                },
+                "FORMAT_GFF2BED": {
+                    "gzip": 1.11
+                },
+                "FORMAT_LOCUS_CONSOLIDATE": {
+                    "gzip": 1.11
                 },
                 "GFF_CAT": {
                     "coreutils": 9.4,
@@ -111,10 +131,16 @@
                 "bbmap/bbmap/SAMPLE2_PE.bbmap.log",
                 "bbmap/bbmap/SAMPLE3_PE_1.bbmap.log",
                 "featurecounts",
+                "featurecounts/SAMPLE1_PE.locus_consolidate.featureCounts.tsv",
+                "featurecounts/SAMPLE1_PE.locus_consolidate.featureCounts.tsv.summary",
                 "featurecounts/SAMPLE1_PE.prokka.featureCounts.tsv",
                 "featurecounts/SAMPLE1_PE.prokka.featureCounts.tsv.summary",
+                "featurecounts/SAMPLE2_PE.locus_consolidate.featureCounts.tsv",
+                "featurecounts/SAMPLE2_PE.locus_consolidate.featureCounts.tsv.summary",
                 "featurecounts/SAMPLE2_PE.prokka.featureCounts.tsv",
                 "featurecounts/SAMPLE2_PE.prokka.featureCounts.tsv.summary",
+                "featurecounts/SAMPLE3_PE_1.locus_consolidate.featureCounts.tsv",
+                "featurecounts/SAMPLE3_PE_1.locus_consolidate.featureCounts.tsv.summary",
                 "featurecounts/SAMPLE3_PE_1.prokka.featureCounts.tsv",
                 "featurecounts/SAMPLE3_PE_1.prokka.featureCounts.tsv.summary",
                 "megahit",
@@ -167,6 +193,7 @@
                 "samtools/megahit.SAMPLE3_PE_1.flagstat",
                 "samtools/megahit.SAMPLE3_PE_1.idxstats",
                 "summary_tables",
+                "summary_tables/megahit.locus_consolidate.counts.tsv.gz",
                 "summary_tables/megahit.prokka.counts.tsv.gz",
                 "summary_tables/megahit.prokka.overall_stats.tsv.gz",
                 "summary_tables/megahit.prokka.prokka-annotations.tsv.gz",
@@ -208,7 +235,7 @@
             ],
             1
         ],
-        "timestamp": "2026-08-19T02:21:44.172646808",
+        "timestamp": "2026-08-20T12:29:10.023209755",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"

--- a/tests/megahit_prokka_prodigal.nf.test.snap
+++ b/tests/megahit_prokka_prodigal.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "-profile test_megahit_prokka_prodigal": {
         "content": [
-            55,
+            64,
             {
                 "BBMAP_ALIGN": {
                     "bbmap": 39.18
@@ -9,10 +9,24 @@
                 "BBMAP_INDEX": {
                     "bbmap": 39.18
                 },
+                "BEDTOOLS_MERGE": {
+                    "bedtools": "2.31.1"
+                },
+                "BEDTOOLS_SORT": {
+                    "bedtools": "2.31.1"
+                },
                 "CAT_FASTQ": {
                     "cat": 9.5
                 },
                 "COLLECT_FEATURECOUNTS": {
+                    "R": "4.5.3",
+                    "dplyr": "1.2.1",
+                    "readr": "2.2.0",
+                    "stringr": "1.6.0",
+                    "dtplyr": "1.3.3",
+                    "data.table": "1.17.8"
+                },
+                "COLLECT_LOCUS_CONSOLIDATE": {
                     "R": "4.5.3",
                     "dplyr": "1.2.1",
                     "readr": "2.2.0",
@@ -43,6 +57,12 @@
                     "coreutils": 9.4,
                     "find": "4.6.0",
                     "pigz": 2.8
+                },
+                "FORMAT_GFF2BED": {
+                    "gzip": 1.11
+                },
+                "FORMAT_LOCUS_CONSOLIDATE": {
+                    "gzip": 1.11
                 },
                 "FORMAT_PRODIGAL_GFF": {
                     "gzip": 1.11
@@ -117,14 +137,20 @@
                 "bbmap/bbmap/SAMPLE2_PE.bbmap.log",
                 "bbmap/bbmap/SAMPLE3_PE_1.bbmap.log",
                 "featurecounts",
+                "featurecounts/SAMPLE1_PE.locus_consolidate.featureCounts.tsv",
+                "featurecounts/SAMPLE1_PE.locus_consolidate.featureCounts.tsv.summary",
                 "featurecounts/SAMPLE1_PE.prodigal.featureCounts.tsv",
                 "featurecounts/SAMPLE1_PE.prodigal.featureCounts.tsv.summary",
                 "featurecounts/SAMPLE1_PE.prokka.featureCounts.tsv",
                 "featurecounts/SAMPLE1_PE.prokka.featureCounts.tsv.summary",
+                "featurecounts/SAMPLE2_PE.locus_consolidate.featureCounts.tsv",
+                "featurecounts/SAMPLE2_PE.locus_consolidate.featureCounts.tsv.summary",
                 "featurecounts/SAMPLE2_PE.prodigal.featureCounts.tsv",
                 "featurecounts/SAMPLE2_PE.prodigal.featureCounts.tsv.summary",
                 "featurecounts/SAMPLE2_PE.prokka.featureCounts.tsv",
                 "featurecounts/SAMPLE2_PE.prokka.featureCounts.tsv.summary",
+                "featurecounts/SAMPLE3_PE_1.locus_consolidate.featureCounts.tsv",
+                "featurecounts/SAMPLE3_PE_1.locus_consolidate.featureCounts.tsv.summary",
                 "featurecounts/SAMPLE3_PE_1.prodigal.featureCounts.tsv",
                 "featurecounts/SAMPLE3_PE_1.prodigal.featureCounts.tsv.summary",
                 "featurecounts/SAMPLE3_PE_1.prokka.featureCounts.tsv",
@@ -186,6 +212,7 @@
                 "samtools/megahit.SAMPLE3_PE_1.flagstat",
                 "samtools/megahit.SAMPLE3_PE_1.idxstats",
                 "summary_tables",
+                "summary_tables/megahit.locus_consolidate.counts.tsv.gz",
                 "summary_tables/megahit.prodigal.counts.tsv.gz",
                 "summary_tables/megahit.prodigal.overall_stats.tsv.gz",
                 "summary_tables/megahit.prokka.counts.tsv.gz",
@@ -233,7 +260,7 @@
                 "sample\tn_post_trimming\tidxs_n_mapped\tidxs_n_unmapped\tn_feature_count"
             ]
         ],
-        "timestamp": "2026-08-19T12:50:08.387320929",
+        "timestamp": "2026-08-20T12:35:18.982626006",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"

--- a/tests/megahit_prokka_transdecoder.nf.test.snap
+++ b/tests/megahit_prokka_transdecoder.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "-profile test_megahit_prokka_transdecoder": {
         "content": [
-            82,
+            91,
             {
                 "BBMAP_ALIGN": {
                     "bbmap": 39.18
@@ -9,10 +9,24 @@
                 "BBMAP_INDEX": {
                     "bbmap": 39.18
                 },
+                "BEDTOOLS_MERGE": {
+                    "bedtools": "2.31.1"
+                },
+                "BEDTOOLS_SORT": {
+                    "bedtools": "2.31.1"
+                },
                 "CAT_FASTQ": {
                     "cat": 9.5
                 },
                 "COLLECT_FEATURECOUNTS": {
+                    "R": "4.5.3",
+                    "dplyr": "1.2.1",
+                    "readr": "2.2.0",
+                    "stringr": "1.6.0",
+                    "dtplyr": "1.3.3",
+                    "data.table": "1.17.8"
+                },
+                "COLLECT_LOCUS_CONSOLIDATE": {
                     "R": "4.5.3",
                     "dplyr": "1.2.1",
                     "readr": "2.2.0",
@@ -57,6 +71,12 @@
                     "tidyr": "1.3.0",
                     "readr": "2.1.4",
                     "stringr": "1.5.0"
+                },
+                "FORMAT_GFF2BED": {
+                    "gzip": 1.11
+                },
+                "FORMAT_LOCUS_CONSOLIDATE": {
+                    "gzip": 1.11
                 },
                 "GFF_CAT": {
                     "coreutils": 9.4,
@@ -172,14 +192,20 @@
                 "diamond_taxonomy/megahit.transdecoder.ncbi-refseq-test.lineage.tsv.gz",
                 "diamond_taxonomy/megahit.transdecoder.ncbi-refseq-test.tsv.gz",
                 "featurecounts",
+                "featurecounts/SAMPLE1_PE.locus_consolidate.featureCounts.tsv",
+                "featurecounts/SAMPLE1_PE.locus_consolidate.featureCounts.tsv.summary",
                 "featurecounts/SAMPLE1_PE.prokka.featureCounts.tsv",
                 "featurecounts/SAMPLE1_PE.prokka.featureCounts.tsv.summary",
                 "featurecounts/SAMPLE1_PE.transdecoder.featureCounts.tsv",
                 "featurecounts/SAMPLE1_PE.transdecoder.featureCounts.tsv.summary",
+                "featurecounts/SAMPLE2_PE.locus_consolidate.featureCounts.tsv",
+                "featurecounts/SAMPLE2_PE.locus_consolidate.featureCounts.tsv.summary",
                 "featurecounts/SAMPLE2_PE.prokka.featureCounts.tsv",
                 "featurecounts/SAMPLE2_PE.prokka.featureCounts.tsv.summary",
                 "featurecounts/SAMPLE2_PE.transdecoder.featureCounts.tsv",
                 "featurecounts/SAMPLE2_PE.transdecoder.featureCounts.tsv.summary",
+                "featurecounts/SAMPLE3_PE_1.locus_consolidate.featureCounts.tsv",
+                "featurecounts/SAMPLE3_PE_1.locus_consolidate.featureCounts.tsv.summary",
                 "featurecounts/SAMPLE3_PE_1.prokka.featureCounts.tsv",
                 "featurecounts/SAMPLE3_PE_1.prokka.featureCounts.tsv.summary",
                 "featurecounts/SAMPLE3_PE_1.transdecoder.featureCounts.tsv",
@@ -235,6 +261,7 @@
                 "samtools/megahit.SAMPLE3_PE_1.flagstat",
                 "samtools/megahit.SAMPLE3_PE_1.idxstats",
                 "summary_tables",
+                "summary_tables/megahit.locus_consolidate.counts.tsv.gz",
                 "summary_tables/megahit.prokka.counts.tsv.gz",
                 "summary_tables/megahit.prokka.gtdb-r220-test.diamond.taxonomy.tsv.gz",
                 "summary_tables/megahit.prokka.ncbi-refseq-test.diamond.taxonomy-taxdump.tsv.gz",
@@ -293,7 +320,7 @@
                 "sample\tn_post_trimming\tidxs_n_mapped\tidxs_n_unmapped\tn_feature_count\tdiamondtax_gtdb-r220-test\tdiamondtax_ncbi-refseq-test"
             ]
         ],
-        "timestamp": "2026-08-19T12:56:04.514305586",
+        "timestamp": "2026-08-20T12:43:20.056437923",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"

--- a/tests/megahit_transdecoder.nf.test.snap
+++ b/tests/megahit_transdecoder.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "-profile test_megahit_transdecoder": {
         "content": [
-            47,
+            55,
             {
                 "BBMAP_ALIGN": {
                     "bbmap": 39.18
@@ -9,10 +9,24 @@
                 "BBMAP_INDEX": {
                     "bbmap": 39.18
                 },
+                "BEDTOOLS_MERGE": {
+                    "bedtools": "2.31.1"
+                },
+                "BEDTOOLS_SORT": {
+                    "bedtools": "2.31.1"
+                },
                 "CAT_FASTQ": {
                     "cat": 9.5
                 },
                 "COLLECT_FEATURECOUNTS": {
+                    "R": "4.5.3",
+                    "dplyr": "1.2.1",
+                    "readr": "2.2.0",
+                    "stringr": "1.6.0",
+                    "dtplyr": "1.3.3",
+                    "data.table": "1.17.8"
+                },
+                "COLLECT_LOCUS_CONSOLIDATE": {
                     "R": "4.5.3",
                     "dplyr": "1.2.1",
                     "readr": "2.2.0",
@@ -33,6 +47,12 @@
                 },
                 "FEATURECOUNTS_CDS": {
                     "subread": "2.1.1"
+                },
+                "FORMAT_GFF2BED": {
+                    "gzip": 1.11
+                },
+                "FORMAT_LOCUS_CONSOLIDATE": {
+                    "gzip": 1.11
                 },
                 "MEGAHIT": {
                     "megahit": "1.2.9"
@@ -99,10 +119,16 @@
                 "bbmap/bbmap/SAMPLE2_PE.bbmap.log",
                 "bbmap/bbmap/SAMPLE3_PE_1.bbmap.log",
                 "featurecounts",
+                "featurecounts/SAMPLE1_PE.locus_consolidate.featureCounts.tsv",
+                "featurecounts/SAMPLE1_PE.locus_consolidate.featureCounts.tsv.summary",
                 "featurecounts/SAMPLE1_PE.transdecoder.featureCounts.tsv",
                 "featurecounts/SAMPLE1_PE.transdecoder.featureCounts.tsv.summary",
+                "featurecounts/SAMPLE2_PE.locus_consolidate.featureCounts.tsv",
+                "featurecounts/SAMPLE2_PE.locus_consolidate.featureCounts.tsv.summary",
                 "featurecounts/SAMPLE2_PE.transdecoder.featureCounts.tsv",
                 "featurecounts/SAMPLE2_PE.transdecoder.featureCounts.tsv.summary",
+                "featurecounts/SAMPLE3_PE_1.locus_consolidate.featureCounts.tsv",
+                "featurecounts/SAMPLE3_PE_1.locus_consolidate.featureCounts.tsv.summary",
                 "featurecounts/SAMPLE3_PE_1.transdecoder.featureCounts.tsv",
                 "featurecounts/SAMPLE3_PE_1.transdecoder.featureCounts.tsv.summary",
                 "megahit",
@@ -150,6 +176,7 @@
                 "samtools/megahit.SAMPLE3_PE_1.flagstat",
                 "samtools/megahit.SAMPLE3_PE_1.idxstats",
                 "summary_tables",
+                "summary_tables/megahit.locus_consolidate.counts.tsv.gz",
                 "summary_tables/megahit.transdecoder.counts.tsv.gz",
                 "summary_tables/megahit.transdecoder.overall_stats.tsv.gz",
                 "transdecoder",
@@ -194,7 +221,7 @@
                 "sample\tn_post_trimming\tidxs_n_mapped\tidxs_n_unmapped\tn_feature_count"
             ]
         ],
-        "timestamp": "2026-08-19T02:32:39.076531654",
+        "timestamp": "2026-08-20T12:47:50.264295088",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"

--- a/tests/metaeuk.nf.test
+++ b/tests/metaeuk.nf.test
@@ -41,6 +41,24 @@ nextflow_pipeline {
                 // be summed into ONE featureCounts row spanning both exon coordinates, not split
                 // into one row per exon (which is what the raw MetaEuk GFF, un-formatted, would do).
                 { assert path("${params.outdir}/summary_tables/megahit.metaeuk.counts.tsv.gz").csv(sep: '\t', decompress: true, header: true).columns["chr"].any { c -> c.contains(';') } },
+
+                // #463 graceful degradation: with only one caller active, locus consolidation has
+                // nothing to merge, so the ID-inheritance rule must reproduce MetaEuk's own solo table
+                // exactly (same rows, minus the callers/n_calls provenance columns it adds).
+                { assert (
+                    ['orf', 'chr', 'start', 'end', 'strand', 'length', 'sample', 'count', 'tpm'].collect { c ->
+                        path("${params.outdir}/summary_tables/megahit.metaeuk.counts.tsv.gz").csv(sep: '\t', decompress: true, header: true).columns[c]
+                    }.transpose().toSet()
+                ) == (
+                    ['orf', 'chr', 'start', 'end', 'strand', 'length', 'sample', 'count', 'tpm'].collect { c ->
+                        path("${params.outdir}/summary_tables/megahit.locus_consolidate.counts.tsv.gz").csv(sep: '\t', decompress: true, header: true).columns[c]
+                    }.transpose().toSet()
+                ) },
+                { assert (
+                    path("${params.outdir}/summary_tables/megahit.locus_consolidate.counts.tsv.gz")
+                        .csv(sep: '\t', decompress: true, header: true).rows
+                        .every { r -> r["callers"] == 'metaeuk' && (r["n_calls"] as int) == 1 }
+                ) },
             )
         }
     }

--- a/tests/metaeuk.nf.test.snap
+++ b/tests/metaeuk.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "-profile test_metaeuk": {
         "content": [
-            40,
+            48,
             {
                 "BBMAP_ALIGN": {
                     "bbmap": 39.18
@@ -9,7 +9,21 @@
                 "BBMAP_INDEX": {
                     "bbmap": 39.18
                 },
+                "BEDTOOLS_MERGE": {
+                    "bedtools": "2.31.1"
+                },
+                "BEDTOOLS_SORT": {
+                    "bedtools": "2.31.1"
+                },
                 "COLLECT_FEATURECOUNTS": {
+                    "R": "4.5.3",
+                    "dplyr": "1.2.1",
+                    "readr": "2.2.0",
+                    "stringr": "1.6.0",
+                    "dtplyr": "1.3.3",
+                    "data.table": "1.17.8"
+                },
+                "COLLECT_LOCUS_CONSOLIDATE": {
                     "R": "4.5.3",
                     "dplyr": "1.2.1",
                     "readr": "2.2.0",
@@ -30,6 +44,12 @@
                 },
                 "FEATURECOUNTS_CDS": {
                     "subread": "2.1.1"
+                },
+                "FORMAT_GFF2BED": {
+                    "gzip": 1.11
+                },
+                "FORMAT_LOCUS_CONSOLIDATE": {
+                    "gzip": 1.11
                 },
                 "FORMAT_METAEUK_GFF": {
                     "gzip": 1.11
@@ -81,10 +101,16 @@
                 "bbmap/bbmap/RPL28_MRNA.bbmap.log",
                 "bbmap/bbmap/RPL28_MRNA_RECODED.bbmap.log",
                 "featurecounts",
+                "featurecounts/RPL28_GENOMIC.locus_consolidate.featureCounts.tsv",
+                "featurecounts/RPL28_GENOMIC.locus_consolidate.featureCounts.tsv.summary",
                 "featurecounts/RPL28_GENOMIC.metaeuk.featureCounts.tsv",
                 "featurecounts/RPL28_GENOMIC.metaeuk.featureCounts.tsv.summary",
+                "featurecounts/RPL28_MRNA.locus_consolidate.featureCounts.tsv",
+                "featurecounts/RPL28_MRNA.locus_consolidate.featureCounts.tsv.summary",
                 "featurecounts/RPL28_MRNA.metaeuk.featureCounts.tsv",
                 "featurecounts/RPL28_MRNA.metaeuk.featureCounts.tsv.summary",
+                "featurecounts/RPL28_MRNA_RECODED.locus_consolidate.featureCounts.tsv",
+                "featurecounts/RPL28_MRNA_RECODED.locus_consolidate.featureCounts.tsv.summary",
                 "featurecounts/RPL28_MRNA_RECODED.metaeuk.featureCounts.tsv",
                 "featurecounts/RPL28_MRNA_RECODED.metaeuk.featureCounts.tsv.summary",
                 "megahit",
@@ -137,6 +163,7 @@
                 "samtools/megahit.RPL28_MRNA_RECODED.flagstat",
                 "samtools/megahit.RPL28_MRNA_RECODED.idxstats",
                 "summary_tables",
+                "summary_tables/megahit.locus_consolidate.counts.tsv.gz",
                 "summary_tables/megahit.metaeuk.counts.tsv.gz",
                 "summary_tables/megahit.metaeuk.overall_stats.tsv.gz",
                 "transrate",
@@ -180,7 +207,7 @@
                 "sample\tn_post_trimming\tidxs_n_mapped\tidxs_n_unmapped\tn_feature_count"
             ]
         ],
-        "timestamp": "2026-08-19T02:36:43.466230835",
+        "timestamp": "2026-08-20T12:09:32.839535339",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"

--- a/tests/metaeuk_transdecoder.nf.test
+++ b/tests/metaeuk_transdecoder.nf.test
@@ -1,0 +1,93 @@
+nextflow_pipeline {
+
+    name "Test pipeline"
+    script "../main.nf"
+    tag "pipeline"
+    profile "test_metaeuk_transdecoder"
+
+    test("-profile test_metaeuk_transdecoder") {
+
+        when {
+            params {
+                outdir = "$outputDir"
+            }
+        }
+
+        then {
+            // stable_name: All files + folders in ${params.outdir}/ with a stable name
+            def stable_name = getAllFilesFromDir(params.outdir, relative: true, includeDir: true, ignore: ['pipeline_info/*.{html,json,txt}', 'multiqc/multiqc_plots', 'multiqc/multiqc_plots/**' ])
+            // stable_path: All files in ${params.outdir}/ with stable content
+            def stable_path = getAllFilesFromDir(params.outdir, ignoreFile: 'tests/.nftignore')
+            assertAll(
+                { assert workflow.success },
+                { assert snapshot(
+                    // Number of successful tasks
+                    workflow.trace.succeeded().size(),
+                    // pipeline versions.yml file for multiqc from which Nextflow version is removed because we test pipelines on multiple Nextflow versions
+                    removeNextflowVersion("$outputDir/pipeline_info/nf_core_metatdenovo_software_mqc_versions.yml"),
+                    // All stable path name, with a relative path
+                    stable_name,
+                    // All files with stable contents
+                    stable_path,
+                    // Per-caller values, in the same style as the existing solo metaeuk test
+                    // (tests/metaeuk.nf.test) -- directly comparable to that test's own .snap values as
+                    // independent confirmation that one caller's results aren't contaminated by the other.
+                    path("${params.outdir}/summary_tables/megahit.metaeuk.counts.tsv.gz").linesGzip.findAll { l -> l.contains('orf') },
+                    path("${params.outdir}/summary_tables/megahit.transdecoder.counts.tsv.gz").linesGzip.findAll { l -> l.contains('orf') },
+                    // The locus-consolidated table itself (#463) -- small enough on this test dataset to
+                    // snapshot verbatim rather than just its header, so any regression in the
+                    // ID-inheritance rule, coordinate round-tripping, or provenance columns shows up as a
+                    // diff here.
+                    path("${params.outdir}/summary_tables/megahit.locus_consolidate.counts.tsv.gz").linesGzip,
+                ).match() },
+                { assert path("${params.outdir}/megahit/megahit_assembly.log").readLines().any { l -> l.contains('ALL DONE') } },
+                { assert path("${params.outdir}/megahit/megahit_assembly.contigs.fa.gz").linesGzip.size() >= 4 },
+
+                // === #463: locus consolidation must not double-count reads shared by two callers ===
+                // k59_0 is the RPL28_MRNA_RECODED locus where MetaEuk and TransDecoder call the exact
+                // same coordinates (1-447, +) for the same real gene: metaeuk's own solo table and
+                // transdecoder's own solo table each independently report all 400 aligned reads for that
+                // sample (naively summing the two per-caller tables would give 800 -- double the true
+                // read count). The consolidated table must report exactly the true, once-only count.
+                { assert (
+                    path("${params.outdir}/summary_tables/megahit.locus_consolidate.counts.tsv.gz")
+                        .csv(sep: '\t', decompress: true, header: true).rows
+                        .findAll { r -> r["sample"] == 'RPL28_MRNA_RECODED' }
+                        .sum { r -> r["count"] as int }
+                ) == 400 },
+                // Provenance on that same merged locus: both callers contributed, two independent calls.
+                { assert (
+                    path("${params.outdir}/summary_tables/megahit.locus_consolidate.counts.tsv.gz")
+                        .csv(sep: '\t', decompress: true, header: true).rows
+                        .find { r -> r["sample"] == 'RPL28_MRNA_RECODED' }
+                        .with { r -> [ r["callers"].tokenize(',').toSet(), r["n_calls"] as int ] }
+                ) == [ ['metaeuk', 'transdecoder'] as Set, 2 ] },
+
+                // === k59_1: MetaEuk's splice-aware call (two exons, - strand) and TransDecoder's
+                // unspliced call (+ strand) overlap in genomic position but are different real gene
+                // models on opposite strands -- bedtools merge's -s (strand-aware) design must keep them
+                // as two separate loci, never merged into one. ===
+                { assert (
+                    path("${params.outdir}/summary_tables/megahit.locus_consolidate.counts.tsv.gz")
+                        .csv(sep: '\t', decompress: true, header: true).rows
+                        .findAll { r -> r["orf"] == 'k59_1.p1' || r["orf"].startsWith('NP_011412.1|k59_1') }
+                        .every { r -> (r["n_calls"] as int) == 1 }
+                ) },
+
+                // Per-sample locus-consolidated read counts never exceed that sample's total aligned
+                // reads (samtools flagstat) -- the general form of the no-double-counting property above,
+                // checked for every sample rather than just the one hand-picked case.
+                { assert (
+                    ['RPL28_GENOMIC', 'RPL28_MRNA', 'RPL28_MRNA_RECODED'].every { sample ->
+                        def consolidated_total = path("${params.outdir}/summary_tables/megahit.locus_consolidate.counts.tsv.gz")
+                            .csv(sep: '\t', decompress: true, header: true).rows
+                            .findAll { r -> r["sample"] == sample }
+                            .sum { r -> r["count"] as int } ?: 0
+                        def flagstat_total = path("${params.outdir}/samtools/megahit.${sample}.flagstat").readLines()[0].tokenize(' ')[0] as int
+                        consolidated_total <= flagstat_total
+                    }
+                ) },
+            )
+        }
+    }
+}

--- a/tests/metaeuk_transdecoder.nf.test.snap
+++ b/tests/metaeuk_transdecoder.nf.test.snap
@@ -1,0 +1,253 @@
+{
+    "-profile test_metaeuk_transdecoder": {
+        "content": [
+            60,
+            {
+                "BBMAP_ALIGN": {
+                    "bbmap": 39.18
+                },
+                "BBMAP_INDEX": {
+                    "bbmap": 39.18
+                },
+                "BEDTOOLS_MERGE": {
+                    "bedtools": "2.31.1"
+                },
+                "BEDTOOLS_SORT": {
+                    "bedtools": "2.31.1"
+                },
+                "COLLECT_FEATURECOUNTS": {
+                    "R": "4.5.3",
+                    "dplyr": "1.2.1",
+                    "readr": "2.2.0",
+                    "stringr": "1.6.0",
+                    "dtplyr": "1.3.3",
+                    "data.table": "1.17.8"
+                },
+                "COLLECT_LOCUS_CONSOLIDATE": {
+                    "R": "4.5.3",
+                    "dplyr": "1.2.1",
+                    "readr": "2.2.0",
+                    "stringr": "1.6.0",
+                    "dtplyr": "1.3.3",
+                    "data.table": "1.17.8"
+                },
+                "COLLECT_STATS": {
+                    "R": "4.5.3",
+                    "dplyr": "1.2.1",
+                    "readr": "2.2.0",
+                    "purrr": "1.2.2",
+                    "tidyr": "1.3.2",
+                    "stringr": "1.6.0"
+                },
+                "FASTQC": {
+                    "fastqc": "0.12.1"
+                },
+                "FEATURECOUNTS_CDS": {
+                    "subread": "2.1.1"
+                },
+                "FORMAT_GFF2BED": {
+                    "gzip": 1.11
+                },
+                "FORMAT_LOCUS_CONSOLIDATE": {
+                    "gzip": 1.11
+                },
+                "FORMAT_METAEUK_GFF": {
+                    "gzip": 1.11
+                },
+                "MEGAHIT": {
+                    "megahit": "1.2.9"
+                },
+                "METAEUK_EASYPREDICT": {
+                    "metaeuk": "6.a5d39d9"
+                },
+                "PIGZ_TRANSDECODER_BED": {
+                    "pigz": 2.8
+                },
+                "PIGZ_TRANSDECODER_CDS": {
+                    "pigz": 2.8
+                },
+                "PIGZ_TRANSDECODER_GFF": {
+                    "pigz": 2.8
+                },
+                "PIGZ_TRANSDECODER_PEP": {
+                    "pigz": 2.8
+                },
+                "SAMTOOLS_FLAGSTAT": {
+                    "samtools": 1.24
+                },
+                "SAMTOOLS_IDXSTATS": {
+                    "samtools": 1.24
+                },
+                "SAMTOOLS_INDEX": {
+                    "samtools": 1.24
+                },
+                "SAMTOOLS_SORT": {
+                    "samtools": 1.24
+                },
+                "SAMTOOLS_STATS": {
+                    "samtools": 1.24
+                },
+                "SEQTK_MERGEPE": {
+                    "seqtk": "1.4-r122"
+                },
+                "TRANSDECODER_LONGORF": {
+                    "transdecoder": "5.7.1"
+                },
+                "TRANSDECODER_PREDICT": {
+                    "transdecoder": "5.7.1"
+                },
+                "TRANSRATE": {
+                    "transrate": "1.0.3"
+                },
+                "TRIMGALORE": {
+                    "trimgalore": "2.3.0"
+                },
+                "UNPIGZ_CONTIGS": {
+                    "pigz": 2.8
+                },
+                "UNPIGZ_GFF": {
+                    "pigz": 2.8
+                },
+                "Workflow": {
+                    "nf-core/metatdenovo": "v1.5.0dev"
+                }
+            },
+            [
+                "bbmap",
+                "bbmap/bbmap",
+                "bbmap/bbmap/RPL28_GENOMIC.bbmap.log",
+                "bbmap/bbmap/RPL28_MRNA.bbmap.log",
+                "bbmap/bbmap/RPL28_MRNA_RECODED.bbmap.log",
+                "featurecounts",
+                "featurecounts/RPL28_GENOMIC.locus_consolidate.featureCounts.tsv",
+                "featurecounts/RPL28_GENOMIC.locus_consolidate.featureCounts.tsv.summary",
+                "featurecounts/RPL28_GENOMIC.metaeuk.featureCounts.tsv",
+                "featurecounts/RPL28_GENOMIC.metaeuk.featureCounts.tsv.summary",
+                "featurecounts/RPL28_GENOMIC.transdecoder.featureCounts.tsv",
+                "featurecounts/RPL28_GENOMIC.transdecoder.featureCounts.tsv.summary",
+                "featurecounts/RPL28_MRNA.locus_consolidate.featureCounts.tsv",
+                "featurecounts/RPL28_MRNA.locus_consolidate.featureCounts.tsv.summary",
+                "featurecounts/RPL28_MRNA.metaeuk.featureCounts.tsv",
+                "featurecounts/RPL28_MRNA.metaeuk.featureCounts.tsv.summary",
+                "featurecounts/RPL28_MRNA.transdecoder.featureCounts.tsv",
+                "featurecounts/RPL28_MRNA.transdecoder.featureCounts.tsv.summary",
+                "featurecounts/RPL28_MRNA_RECODED.locus_consolidate.featureCounts.tsv",
+                "featurecounts/RPL28_MRNA_RECODED.locus_consolidate.featureCounts.tsv.summary",
+                "featurecounts/RPL28_MRNA_RECODED.metaeuk.featureCounts.tsv",
+                "featurecounts/RPL28_MRNA_RECODED.metaeuk.featureCounts.tsv.summary",
+                "featurecounts/RPL28_MRNA_RECODED.transdecoder.featureCounts.tsv",
+                "featurecounts/RPL28_MRNA_RECODED.transdecoder.featureCounts.tsv.summary",
+                "megahit",
+                "megahit/megahit_assembly.contigs.fa.gz",
+                "megahit/megahit_assembly.log",
+                "metaeuk",
+                "metaeuk/megahit.metaeuk.codon.fas",
+                "metaeuk/megahit.metaeuk.fas",
+                "metaeuk/megahit.metaeuk.gff",
+                "metaeuk/megahit.metaeuk.headersMap.tsv",
+                "metaeuk/megahit.metaeuk_format.gff.gz",
+                "multiqc",
+                "multiqc/multiqc_data",
+                "multiqc/multiqc_data/fastqc-status-check-heatmap.txt",
+                "multiqc/multiqc_data/fastqc_overrepresented_sequences_plot.txt",
+                "multiqc/multiqc_data/fastqc_per_base_n_content_plot.txt",
+                "multiqc/multiqc_data/fastqc_per_base_sequence_quality_plot.txt",
+                "multiqc/multiqc_data/fastqc_per_sequence_gc_content_plot_Counts.txt",
+                "multiqc/multiqc_data/fastqc_per_sequence_gc_content_plot_Percentages.txt",
+                "multiqc/multiqc_data/fastqc_per_sequence_quality_scores_plot.txt",
+                "multiqc/multiqc_data/fastqc_sequence_counts_plot.txt",
+                "multiqc/multiqc_data/fastqc_sequence_duplication_levels_plot.txt",
+                "multiqc/multiqc_data/fastqc_sequence_length_distribution_plot.txt",
+                "multiqc/multiqc_data/fastqc_top_overrepresented_sequences_table.txt",
+                "multiqc/multiqc_data/llms-full.txt",
+                "multiqc/multiqc_data/multiqc.log",
+                "multiqc/multiqc_data/multiqc.parquet",
+                "multiqc/multiqc_data/multiqc_citations.txt",
+                "multiqc/multiqc_data/multiqc_data.json",
+                "multiqc/multiqc_data/multiqc_fastqc.txt",
+                "multiqc/multiqc_data/multiqc_general_stats.txt",
+                "multiqc/multiqc_data/multiqc_megahit_assemblies.txt",
+                "multiqc/multiqc_data/multiqc_metaeuk_stats.txt",
+                "multiqc/multiqc_data/multiqc_software_versions.txt",
+                "multiqc/multiqc_data/multiqc_sources.txt",
+                "multiqc/multiqc_data/multiqc_transdecoder_stats.txt",
+                "multiqc/multiqc_report.html",
+                "pipeline_info",
+                "pipeline_info/nf_core_metatdenovo_software_mqc_versions.yml",
+                "samtools",
+                "samtools/RPL28_GENOMIC.sorted.bam",
+                "samtools/RPL28_GENOMIC.sorted.bam.bai",
+                "samtools/RPL28_MRNA.sorted.bam",
+                "samtools/RPL28_MRNA.sorted.bam.bai",
+                "samtools/RPL28_MRNA_RECODED.sorted.bam",
+                "samtools/RPL28_MRNA_RECODED.sorted.bam.bai",
+                "samtools/megahit.RPL28_GENOMIC.flagstat",
+                "samtools/megahit.RPL28_GENOMIC.idxstats",
+                "samtools/megahit.RPL28_MRNA.flagstat",
+                "samtools/megahit.RPL28_MRNA.idxstats",
+                "samtools/megahit.RPL28_MRNA_RECODED.flagstat",
+                "samtools/megahit.RPL28_MRNA_RECODED.idxstats",
+                "summary_tables",
+                "summary_tables/megahit.locus_consolidate.counts.tsv.gz",
+                "summary_tables/megahit.metaeuk.counts.tsv.gz",
+                "summary_tables/megahit.metaeuk.overall_stats.tsv.gz",
+                "summary_tables/megahit.transdecoder.counts.tsv.gz",
+                "summary_tables/megahit.transdecoder.overall_stats.tsv.gz",
+                "transdecoder",
+                "transdecoder/megahit_assembly.contigs.fa.transdecoder.bed.gz",
+                "transdecoder/megahit_assembly.contigs.fa.transdecoder.cds.gz",
+                "transdecoder/megahit_assembly.contigs.fa.transdecoder.gff3.gz",
+                "transdecoder/megahit_assembly.contigs.fa.transdecoder.pep.gz",
+                "transrate",
+                "transrate/megahit.assemblies.csv",
+                "transrate/megahit.contigs.csv",
+                "trimgalore",
+                "trimgalore/RPL28_GENOMIC_1.fastq.gz_trimming_report.txt",
+                "trimgalore/RPL28_GENOMIC_2.fastq.gz_trimming_report.txt",
+                "trimgalore/RPL28_MRNA_1.fastq.gz_trimming_report.txt",
+                "trimgalore/RPL28_MRNA_2.fastq.gz_trimming_report.txt",
+                "trimgalore/RPL28_MRNA_RECODED_1.fastq.gz_trimming_report.txt",
+                "trimgalore/RPL28_MRNA_RECODED_2.fastq.gz_trimming_report.txt",
+                "trimgalore/fastqc",
+                "trimgalore/fastqc/RPL28_GENOMIC_1_val_1_fastqc.html",
+                "trimgalore/fastqc/RPL28_GENOMIC_1_val_1_fastqc.zip",
+                "trimgalore/fastqc/RPL28_GENOMIC_2_val_2_fastqc.html",
+                "trimgalore/fastqc/RPL28_GENOMIC_2_val_2_fastqc.zip",
+                "trimgalore/fastqc/RPL28_MRNA_1_val_1_fastqc.html",
+                "trimgalore/fastqc/RPL28_MRNA_1_val_1_fastqc.zip",
+                "trimgalore/fastqc/RPL28_MRNA_2_val_2_fastqc.html",
+                "trimgalore/fastqc/RPL28_MRNA_2_val_2_fastqc.zip",
+                "trimgalore/fastqc/RPL28_MRNA_RECODED_1_val_1_fastqc.html",
+                "trimgalore/fastqc/RPL28_MRNA_RECODED_1_val_1_fastqc.zip",
+                "trimgalore/fastqc/RPL28_MRNA_RECODED_2_val_2_fastqc.html",
+                "trimgalore/fastqc/RPL28_MRNA_RECODED_2_val_2_fastqc.zip"
+            ],
+            [
+                "megahit.metaeuk.codon.fas:md5,8bc52c564165881a622d69413cf33452",
+                "megahit.metaeuk.fas:md5,cab473bca453ec98053f2544d9a01a1c",
+                "megahit.metaeuk.gff:md5,f5ceef9a3b9917aeb174e1374d566e28",
+                "megahit.metaeuk.headersMap.tsv:md5,5ec29818faeff6db35900f11e8e55738",
+                "megahit.metaeuk_format.gff.gz:md5,9f4ba2f29292871fb361b621124cb2b2",
+                "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f",
+                "multiqc_metaeuk_stats.txt:md5,be6038955478f96fdcaaa12d04c6d4a9"
+            ],
+            [
+                "orf\tchr\tstart\tend\tstrand\tlength\tsample\tcount\ttpm"
+            ],
+            [
+                "orf\tchr\tstart\tend\tstrand\tlength\tsample\tcount\ttpm"
+            ],
+            [
+                "orf\tchr\tstart\tend\tstrand\tlength\tsample\tcount\ttpm\tcallers\tn_calls",
+                "k59_1.p1\tk59_1\t183\t611\t+\t429\tRPL28_GENOMIC\t12\t153410.5534105534\ttransdecoder\t1",
+                "NP_011412.1|k59_1|-|191\tk59_1;k59_1\t192;1102\t590;1149\t-;-\t447\tRPL28_GENOMIC\t69\t846589.4465894466\tmetaeuk\t1",
+                "locus_k59_0_1_447_+\tk59_0\t1\t447\t+\t447\tRPL28_MRNA_RECODED\t400\t1000000\tmetaeuk,transdecoder\t2"
+            ]
+        ],
+        "timestamp": "2026-08-20T12:06:04.245443485",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
+        }
+    }
+}

--- a/tests/single.nf.test.snap
+++ b/tests/single.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "-profile test_single": {
         "content": [
-            69,
+            79,
             {
                 "BBMAP_ALIGN": {
                     "bbmap": 39.18
@@ -12,10 +12,24 @@
                 "BBMAP_INDEX": {
                     "bbmap": 39.18
                 },
+                "BEDTOOLS_MERGE": {
+                    "bedtools": "2.31.1"
+                },
+                "BEDTOOLS_SORT": {
+                    "bedtools": "2.31.1"
+                },
                 "CAT_FASTQ": {
                     "cat": 9.5
                 },
                 "COLLECT_FEATURECOUNTS": {
+                    "R": "4.5.3",
+                    "dplyr": "1.2.1",
+                    "readr": "2.2.0",
+                    "stringr": "1.6.0",
+                    "dtplyr": "1.3.3",
+                    "data.table": "1.17.8"
+                },
+                "COLLECT_LOCUS_CONSOLIDATE": {
                     "R": "4.5.3",
                     "dplyr": "1.2.1",
                     "readr": "2.2.0",
@@ -36,6 +50,12 @@
                 },
                 "FEATURECOUNTS_CDS": {
                     "subread": "2.1.1"
+                },
+                "FORMAT_GFF2BED": {
+                    "gzip": 1.11
+                },
+                "FORMAT_LOCUS_CONSOLIDATE": {
+                    "gzip": 1.11
                 },
                 "FORMAT_PRODIGAL_GFF": {
                     "gzip": 1.11
@@ -101,14 +121,24 @@
                 "bbmap/bbmap/SAMPLE4_PE_1.bbmap.log",
                 "bbmap/bbmap/SAMPLE5_PE.bbmap.log",
                 "featurecounts",
+                "featurecounts/SAMPLE1_SE.locus_consolidate.featureCounts.tsv",
+                "featurecounts/SAMPLE1_SE.locus_consolidate.featureCounts.tsv.summary",
                 "featurecounts/SAMPLE1_SE.prodigal.featureCounts.tsv",
                 "featurecounts/SAMPLE1_SE.prodigal.featureCounts.tsv.summary",
+                "featurecounts/SAMPLE2_SE.locus_consolidate.featureCounts.tsv",
+                "featurecounts/SAMPLE2_SE.locus_consolidate.featureCounts.tsv.summary",
                 "featurecounts/SAMPLE2_SE.prodigal.featureCounts.tsv",
                 "featurecounts/SAMPLE2_SE.prodigal.featureCounts.tsv.summary",
+                "featurecounts/SAMPLE3_SE.locus_consolidate.featureCounts.tsv",
+                "featurecounts/SAMPLE3_SE.locus_consolidate.featureCounts.tsv.summary",
                 "featurecounts/SAMPLE3_SE.prodigal.featureCounts.tsv",
                 "featurecounts/SAMPLE3_SE.prodigal.featureCounts.tsv.summary",
+                "featurecounts/SAMPLE4_PE_1.locus_consolidate.featureCounts.tsv",
+                "featurecounts/SAMPLE4_PE_1.locus_consolidate.featureCounts.tsv.summary",
                 "featurecounts/SAMPLE4_PE_1.prodigal.featureCounts.tsv",
                 "featurecounts/SAMPLE4_PE_1.prodigal.featureCounts.tsv.summary",
+                "featurecounts/SAMPLE5_PE.locus_consolidate.featureCounts.tsv",
+                "featurecounts/SAMPLE5_PE.locus_consolidate.featureCounts.tsv.summary",
                 "featurecounts/SAMPLE5_PE.prodigal.featureCounts.tsv",
                 "featurecounts/SAMPLE5_PE.prodigal.featureCounts.tsv.summary",
                 "megahit",
@@ -173,6 +203,7 @@
                 "samtools/megahit.SAMPLE5_PE.flagstat",
                 "samtools/megahit.SAMPLE5_PE.idxstats",
                 "summary_tables",
+                "summary_tables/megahit.locus_consolidate.counts.tsv.gz",
                 "summary_tables/megahit.prodigal.counts.tsv.gz",
                 "summary_tables/megahit.prodigal.overall_stats.tsv.gz",
                 "transrate",
@@ -215,7 +246,7 @@
                 "sample\tn_post_trimming\tn_non_contaminated\tidxs_n_mapped\tidxs_n_unmapped\tn_feature_count"
             ]
         ],
-        "timestamp": "2026-08-19T02:48:41.551133572",
+        "timestamp": "2026-08-20T12:52:03.739555573",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"

--- a/tests/spades_prodigal.nf.test.snap
+++ b/tests/spades_prodigal.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "-profile test_spades_prodigal": {
         "content": [
-            46,
+            54,
             {
                 "BBMAP_ALIGN": {
                     "bbmap": 39.18
@@ -9,10 +9,24 @@
                 "BBMAP_INDEX": {
                     "bbmap": 39.18
                 },
+                "BEDTOOLS_MERGE": {
+                    "bedtools": "2.31.1"
+                },
+                "BEDTOOLS_SORT": {
+                    "bedtools": "2.31.1"
+                },
                 "CAT_FASTQ": {
                     "cat": 9.5
                 },
                 "COLLECT_FEATURECOUNTS": {
+                    "R": "4.5.3",
+                    "dplyr": "1.2.1",
+                    "readr": "2.2.0",
+                    "stringr": "1.6.0",
+                    "dtplyr": "1.3.3",
+                    "data.table": "1.17.8"
+                },
+                "COLLECT_LOCUS_CONSOLIDATE": {
                     "R": "4.5.3",
                     "dplyr": "1.2.1",
                     "readr": "2.2.0",
@@ -35,6 +49,12 @@
                     "subread": "2.1.1"
                 },
                 "FORMATSPADES": {
+                    "gzip": 1.11
+                },
+                "FORMAT_GFF2BED": {
+                    "gzip": 1.11
+                },
+                "FORMAT_LOCUS_CONSOLIDATE": {
                     "gzip": 1.11
                 },
                 "FORMAT_PRODIGAL_GFF": {
@@ -93,10 +113,16 @@
                 "bbmap/bbmap/SAMPLE2_PE.bbmap.log",
                 "bbmap/bbmap/SAMPLE3_PE_1.bbmap.log",
                 "featurecounts",
+                "featurecounts/SAMPLE1_PE.locus_consolidate.featureCounts.tsv",
+                "featurecounts/SAMPLE1_PE.locus_consolidate.featureCounts.tsv.summary",
                 "featurecounts/SAMPLE1_PE.prodigal.featureCounts.tsv",
                 "featurecounts/SAMPLE1_PE.prodigal.featureCounts.tsv.summary",
+                "featurecounts/SAMPLE2_PE.locus_consolidate.featureCounts.tsv",
+                "featurecounts/SAMPLE2_PE.locus_consolidate.featureCounts.tsv.summary",
                 "featurecounts/SAMPLE2_PE.prodigal.featureCounts.tsv",
                 "featurecounts/SAMPLE2_PE.prodigal.featureCounts.tsv.summary",
+                "featurecounts/SAMPLE3_PE_1.locus_consolidate.featureCounts.tsv",
+                "featurecounts/SAMPLE3_PE_1.locus_consolidate.featureCounts.tsv.summary",
                 "featurecounts/SAMPLE3_PE_1.prodigal.featureCounts.tsv",
                 "featurecounts/SAMPLE3_PE_1.prodigal.featureCounts.tsv.summary",
                 "multiqc",
@@ -152,6 +178,7 @@
                 "spades/spades.transcripts.fa.gz",
                 "spades/spades.yaml",
                 "summary_tables",
+                "summary_tables/spades.locus_consolidate.counts.tsv.gz",
                 "summary_tables/spades.prodigal.counts.tsv.gz",
                 "summary_tables/spades.prodigal.overall_stats.tsv.gz",
                 "transrate",
@@ -191,7 +218,7 @@
                 "sample\tn_post_trimming\tidxs_n_mapped\tidxs_n_unmapped\tn_feature_count"
             ]
         ],
-        "timestamp": "2026-08-19T02:56:10.701423118",
+        "timestamp": "2026-08-20T12:55:46.026941046",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"

--- a/workflows/metatdenovo.nf
+++ b/workflows/metatdenovo.nf
@@ -652,9 +652,15 @@ workflow METATDENOVO {
 
     // Locus-consolidated counts get their own collect module (provenance join), branched out here
     // so COLLECT_FEATURECOUNTS itself -- and every other caller's table -- stays untouched.
+    // Keyed by meta.id (not .combine(), which would cross-join every assembly's featureCounts
+    // group against every assembly's provenance file if this pipeline ever ran multiple
+    // simultaneous assemblies) -- matches ch_featurecounts/ch_collect_feature's own convention
+    // just above of staying joinable rather than relying on positional/cardinality pairing.
     COLLECT_LOCUS_CONSOLIDATE (
         ch_collect_feature.locus_consolidate
-            .combine( FORMAT_LOCUS_CONSOLIDATE.out.provenance.map { _meta, provenance -> provenance } )
+            .map { meta, fcs -> [ meta.id, meta, fcs ] }
+            .join( FORMAT_LOCUS_CONSOLIDATE.out.provenance.map { meta, provenance -> [ meta.id, provenance ] } )
+            .map { _id, meta, fcs, provenance -> [ meta, fcs, provenance ] }
     )
     ch_versions = ch_versions.mix(COLLECT_LOCUS_CONSOLIDATE.out.versions)
 

--- a/workflows/metatdenovo.nf
+++ b/workflows/metatdenovo.nf
@@ -113,7 +113,7 @@ workflow METATDENOVO {
     if ( ( params.assembler && params.user_assembly ) || ( ! params.assembler && ! params.user_assembly ) ) {
         error "Provide either `--assembler` or `--user_assembly`!"
     }
-    if ( ( params.orf_caller && ( params.user_orfs_gff ) ) && ( ! params.orf_caller && ! params.user_orfs_gff ) ) {
+    if ( ( params.orf_caller && params.user_orfs_gff ) || ( ! params.orf_caller && ! params.user_orfs_gff ) ) {
         error "Provide either `--orf_caller` or `--user_orfs_gff`/`--user_orfs_faa`!"
     }
 

--- a/workflows/metatdenovo.nf
+++ b/workflows/metatdenovo.nf
@@ -9,6 +9,8 @@
 //
 include { COLLECT_FEATURECOUNTS              } from '../modules/local/collect/featurecounts/'
 include { COLLECT_STATS                      } from '../modules/local/collect/stats/'
+include { FORMAT_GFF2BED                     } from '../modules/local/format/gff2bed/'
+include { FORMAT_LOCUS_CONSOLIDATE           } from '../modules/local/format/locus_consolidate/'
 include { FORMATSPADES                       } from '../modules/local/format/spades/'
 include { MERGE_TABLES                       } from '../modules/local/merge/summary/'
 include { FORMAT_DIAMOND_TAX_RANKLIST        } from '../modules/local/diamond/format_tax/ranklist/'
@@ -52,6 +54,8 @@ include { BBMAP_ALIGN                                } from '../modules/nf-core/
 include { BBMAP_BBDUK                                } from '../modules/nf-core/bbmap/bbduk/'
 include { BBMAP_BBNORM                               } from '../modules/nf-core/bbmap/bbnorm/'
 include { BBMAP_INDEX                                } from '../modules/nf-core/bbmap/index/'
+include { BEDTOOLS_MERGE                             } from '../modules/nf-core/bedtools/merge/'
+include { BEDTOOLS_SORT                              } from '../modules/nf-core/bedtools/sort/'
 include { CAT_FASTQ            	                     } from '../modules/nf-core/cat/fastq/'
 include { DIAMOND_BLASTP as DIAMOND_TAXONOMY         } from '../modules/nf-core/diamond/blastp/'
 include { FASTQC                                     } from '../modules/nf-core/fastqc/'
@@ -532,6 +536,32 @@ workflow METATDENOVO {
     // comment above for why this can't be one call per caller branch.
     UNPIGZ_GFF(ch_gff_gz)
     ch_gff = ch_gff.mix(UNPIGZ_GFF.out.file)
+
+    //
+    // Consolidate overlapping same-contig CDS calls from different active callers into single loci
+    // before counting, so a read supporting one real gene isn't counted once per caller that called
+    // it (#463). Runs unconditionally, even with a single active caller: with nothing to overlap,
+    // every bedtools-merge row has exactly one contributor, so FORMAT_LOCUS_CONSOLIDATE's
+    // ID-inheritance rule reproduces that caller's own GFF byte-for-byte -- graceful degradation,
+    // no separate code path. Rides through the existing, unmodified ch_featurecounts cross-product
+    // and FEATURECOUNTS_CDS call below by being mixed into ch_gff as just another caller.
+    //
+    // versions_gzip/versions_bedtools are topic:versions tuple emits, not versions.yml Paths --
+    // like every other module's topic-based version emit in this pipeline, they're picked up
+    // automatically by the global channel.topic("versions") collection below and must not be
+    // mixed into ch_versions directly (that expects Path entries only).
+    FORMAT_GFF2BED ( ch_gff )
+
+    ch_locus_bed = FORMAT_GFF2BED.out.bed
+        .map { _meta, bed -> bed }
+        .collectFile(name: "${assembly_name}.combined.bed", sort: true)
+        .map { bed -> [ [ id: "${assembly_name}.locus_consolidate", caller: 'locus_consolidate' ], bed ] }
+
+    BEDTOOLS_SORT ( ch_locus_bed, [] )
+    BEDTOOLS_MERGE ( BEDTOOLS_SORT.out.sorted )
+    FORMAT_LOCUS_CONSOLIDATE ( BEDTOOLS_MERGE.out.bed )
+
+    ch_gff = ch_gff.mix(FORMAT_LOCUS_CONSOLIDATE.out.gff)
 
     // Populate channels if the user provided the orfs
     if ( params.user_orfs_faa && params.user_orfs_gff ) {

--- a/workflows/metatdenovo.nf
+++ b/workflows/metatdenovo.nf
@@ -8,6 +8,7 @@
 // MODULE: local
 //
 include { COLLECT_FEATURECOUNTS              } from '../modules/local/collect/featurecounts/'
+include { COLLECT_LOCUS_CONSOLIDATE          } from '../modules/local/collect/locus_consolidate/'
 include { COLLECT_STATS                      } from '../modules/local/collect/stats/'
 include { FORMAT_GFF2BED                     } from '../modules/local/format/gff2bed/'
 include { FORMAT_LOCUS_CONSOLIDATE           } from '../modules/local/format/locus_consolidate/'
@@ -644,8 +645,20 @@ workflow METATDENOVO {
         .map { meta, fc -> [ meta.caller, fc ] }
         .groupTuple()
         .map { caller, fcs -> [ [ id: "${assembly_name}.${caller}", caller: caller ], fcs ] }
+        .branch { meta, _fcs ->
+            locus_consolidate: meta.caller == 'locus_consolidate'
+            other: true
+        }
 
-    COLLECT_FEATURECOUNTS ( ch_collect_feature )
+    // Locus-consolidated counts get their own collect module (provenance join), branched out here
+    // so COLLECT_FEATURECOUNTS itself -- and every other caller's table -- stays untouched.
+    COLLECT_LOCUS_CONSOLIDATE (
+        ch_collect_feature.locus_consolidate
+            .combine( FORMAT_LOCUS_CONSOLIDATE.out.provenance.map { _meta, provenance -> provenance } )
+    )
+    ch_versions = ch_versions.mix(COLLECT_LOCUS_CONSOLIDATE.out.versions)
+
+    COLLECT_FEATURECOUNTS ( ch_collect_feature.other )
     ch_versions           = ch_versions.mix(COLLECT_FEATURECOUNTS.out.versions)
     // [ meta(caller), tsv ] -- kept as a proper tuple (not stripped) so every consumer below can
     // join it against other per-caller channels instead of relying on positional channel pairing.


### PR DESCRIPTION
<!--
# nf-core/metatdenovo pull request

Many thanks for contributing to nf-core/metatdenovo!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/metatdenovo/tree/master/docs/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/metatdenovo/tree/master/docs/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/metatdenovo _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

## Description

Addresses #463.

When more than one `--orf_caller` is active (see #462/#466), each caller currently produces its own completely independent output table.
If two active callers call overlapping or identical-coordinate CDS features on the same contig for what's really the same gene, summing their tables double-counts every read supporting that locus.

This PR adds a new, additional output, `summary_tables/<assembly>.locus_consolidate.counts.tsv.gz`, where overlapping same-contig, same-strand calls from different callers are merged into one locus **before** counting.
Each active caller's own per-caller table and counting still happens exactly as before -- this table is produced alongside them, not instead of them.

### Design

- `FORMAT_GFF2BED` converts each active caller's CDS GFF to BED6, tagging the name column `<caller>:<original ID>`.
- All callers' BED output is concatenated, sorted, and merged with `bedtools merge -s` (strand-aware, so same-position opposite-strand calls are correctly kept separate).
- `FORMAT_LOCUS_CONSOLIDATE` turns the merged intervals back into a GFF, applying an ID-inheritance rule: a locus with exactly one distinct contributor keeps that contributor's own original ID verbatim; a locus with several distinct contributors gets a fresh coordinate-derived ID. This is what makes the feature degrade gracefully -- **with a single caller active, every merged locus has exactly one contributor, so the consolidated table is identical in content to that caller's own table** (verified in `tests/metaeuk.nf.test`).
- The consolidated GFF rides through the pipeline's existing, unmodified `FEATURECOUNTS_CDS` cross-product as just another "caller," so counting logic itself needed no changes.
- `COLLECT_LOCUS_CONSOLIDATE` (a near-clone of the existing `COLLECT_FEATURECOUNTS`) joins in a provenance table (`callers`, `n_calls` columns) recording which caller(s) contributed to each locus and how many independent calls were merged.
- `COLLECT_FEATURECOUNTS` and `FEATURECOUNTS_CDS` themselves are completely untouched -- zero risk to any existing per-caller output.

### Testing

- New `tests/metaeuk_transdecoder.nf.test`: on real overlapping MetaEuk+TransDecoder calls on the RPL28 test data, asserts the consolidated table reports the true (not double-counted) read total, correct `callers`/`n_calls` provenance on the merged locus, and that a same-position-opposite-strand pair of calls correctly stays split into two loci.
- Extended `tests/metaeuk.nf.test` to assert the single-caller degeneracy property explicitly.
- All other existing pipeline tests' snapshots updated, since this step now runs (as a no-op merge) for every caller combination, not just multi-caller runs.

### Post-implementation review

Ran a focused self-review pass after the initial implementation (independent of the main implementation work), which surfaced two issues fixed here:

- `COLLECT_LOCUS_CONSOLIDATE`'s original wiring used an unkeyed `.combine()` between the featureCounts and provenance channels -- safe today only because both are singleton channels (one assembly per run), but a real hazard if the pipeline is ever extended to multiple simultaneous assemblies. Switched to a `.join()` keyed on `meta.id`.
- Found and fixed a pre-existing, unrelated dead validation check (`--orf_caller`/`--user_orfs_gff` mutual-exclusivity, tautological condition that could never fire) while tracing how `ch_gff` is populated.

Not in scope (per #463 itself): cross-contig consolidation (tracked separately, #460).
